### PR TITLE
Added Elasticsearch service example, fixes drud/ddev#1659

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Don't forget the [Official documentation](https://ddev.readthedocs.io/en/stable/
 * [Communication between two ddev projects](docker-compose-snippets/project-communication/README.md)
 
 ## Additional services added via docker-compose.\<service\>.yaml
+
+General information on how to do additional services and some additional examples are [in the docs](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
+
 * [MongoDB](docker-compose-services/mongodb/README.md)
 * [Blackfire.io](docker-compose-services/blackfire/README.md)
 * [PostreSQL](docker-compose-services/postgres/README.md)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Don't forget the [Official documentation](https://ddev.readthedocs.io/en/stable/
 * [MongoDB](docker-compose-services/mongodb/README.md)
 * [Blackfire.io](docker-compose-services/blackfire/README.md)
 * [PostreSQL](docker-compose-services/postgres/README.md)
+* [Elasticsearch](docker-compose-services/elasticsearch/README.md)
 
 ## .ddev/web-build/Dockerfile examples to customize web container
 

--- a/docker-compose-services/elasticsearch/README.md
+++ b/docker-compose-services/elasticsearch/README.md
@@ -17,3 +17,11 @@ You can access the Elasticsearch server directly from the host for debugging pur
 ### Memory Limit
 
 This configuration limits memory usage to 512mb. This should be enough for most projects, but if your `elasticsearch` service stops with no obvious reason, increase your docker max memory or/and the service max memory.  
+
+You can use `ddev logs -s elasticsearch` to investigate what the elasticsearch daemon has been up to, or if you have a RAM-related crash.
+
+### Additional Resources
+
+* There are two related answers to the [Stack Overflow question](https://stackoverflow.com/questions/54575785/how-can-i-use-an-elasticsearch-add-on-container-service-with-ddev) on ddev and Elasticsearch.
+* @juampynr's Lullabot [article on Drupal 8 and Elasticsearch](https://www.lullabot.com/articles/indexing-content-from-drupal-8-to-elasticsearch) is helpful for Drupal users.
+

--- a/docker-compose-services/elasticsearch/README.md
+++ b/docker-compose-services/elasticsearch/README.md
@@ -1,0 +1,15 @@
+## Elasticsearch
+
+Using official Elasticsearch container [elasticsearch](https://hub.docker.com/_/elasticsearch).
+
+### Installation
+
+1. Copy `docker-compose-elasticsearch.yaml` to your project
+
+### Connection
+
+Host: `http://<DDEV_STENAME>.ddev.site:9200`
+
+### Memory Limit
+
+This configuration limits memory usage to 512mb. This should be enough for most projects, but if your `elasticsearch` service stops with no obvious reason, increase your docker max memory or/and the service max memory.  

--- a/docker-compose-services/elasticsearch/README.md
+++ b/docker-compose-services/elasticsearch/README.md
@@ -4,11 +4,15 @@ Using official Elasticsearch container [elasticsearch](https://hub.docker.com/_/
 
 ### Installation
 
-1. Copy `docker-compose-elasticsearch.yaml` to your project
+1. Copy [docker-compose-elasticsearch.yaml](docker-compose-elasticsearch.yaml) to your project
+
+### Configuration
+
+From within the container, the elasticsearch container is reached at hostname: elasticsearch, port: 9200, so the server URL might be `http://elasticsearch:9200`. 
 
 ### Connection
 
-Host: `http://<DDEV_STENAME>.ddev.site:9200`
+You can access the Elasticsearch server directly from the host for debugging purposes by visiting `http://<DDEV_STENAME>.ddev.site:9200`
 
 ### Memory Limit
 

--- a/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
@@ -1,7 +1,8 @@
 version: '3.6'
 services:
   elasticsearch:
-    container_name: ddev-`${DDEV_SITENAME}`-elasticsearch
+    container_name: ddev-${DDEV_SITENAME}-elasticsearch
+    hostname: ${DDEV_SITENAME}-elasticsearch
     image: elasticsearch:5.6
     ports:
       - "9200"
@@ -15,7 +16,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
-      com.ddev.app-url: $DDEV_URL
   web:
     links:
       - elasticsearch:elasticsearch

--- a/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
@@ -1,0 +1,21 @@
+version: '3.6'
+services:
+  elasticsearch:
+    container_name: ddev-`${DDEV_SITENAME}`-elasticsearch
+    image: elasticsearch:5.6
+    ports:
+      - "9200"
+      - "9300"
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9200
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.app-url: $DDEV_URL
+  web:
+    links:
+      - elasticsearch:elasticsearch

--- a/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose-elasticsearch.yaml
@@ -16,6 +16,13 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+      - ".:/mnt/ddev_config"
   web:
     links:
       - elasticsearch:elasticsearch
+
+volumes:
+  elasticsearch:
+    name: "${DDEV_SITENAME}-elasticsearch"


### PR DESCRIPTION
Example of the configuration we use internally for using Elasticsearch with ddev

In our case, we don't need to restore data after a stop/start.