### PR TITLE
Improve custom PHP instructions for blackfire, fixes #25

### DIFF
--- a/docker-compose-services/blackfire/README.md
+++ b/docker-compose-services/blackfire/README.md
@@ -14,10 +14,8 @@ The probe is a PHP module which is already installed on a default DDEV setup.
 
 The agent is provided as docker image by blackfire. Add it to your setup via the provided [docker-compose.blackfire.yaml](docker-compose.blackfire.yaml). Make sure to edit the `BLACKFIRE_SERVER_ID` and `BLACKFIRE_SERVER_TOKEN` environment variables set there.
 
-To make sure the probe and agent can communicate, you will need to override
-the blackfire agent socket in a [custom PHP configuration file as outlined in the DDEV documentation](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini). A working configuration can be copied from the provided [php/blackfire.ini](php/blackfire.ini), which contains:
-
-`blackfire.agent_socket = tcp://blackfire:8707`
+To make sure the probe and agent can communicate, you must override
+the blackfire agent socket in a custom PHP config file ([docs](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini)). Place the provided [php/blackfire.ini](php/blackfire.ini) in .ddev/php and will work fine; it contains`blackfire.agent_socket = tcp://blackfire:8707`
 
 ### The Client
 

--- a/docker-compose-services/blackfire/README.md
+++ b/docker-compose-services/blackfire/README.md
@@ -14,7 +14,8 @@ The probe is a PHP module which is already installed on a default DDEV setup.
 
 The agent is provided as docker image by blackfire. Add it to your setup via the provided [docker-compose.blackfire.yaml](docker-compose.blackfire.yaml). Make sure to edit the `BLACKFIRE_SERVER_ID` and `BLACKFIRE_SERVER_TOKEN` environment variables set there.
 
-To make sure the probe and agent can communicate, adjust the blackfire agent socket via the provided [php/blackfire.ini](php/blackfire.ini), which contains: 
+To make sure the probe and agent can communicate, you will need to override
+the blackfire agent socket in a [custom PHP configuration file as outlined in the DDEV documentation](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini). A working configuration can be copied from the provided [php/blackfire.ini](php/blackfire.ini), which contains:
 
 `blackfire.agent_socket = tcp://blackfire:8707`
 
@@ -22,7 +23,7 @@ To make sure the probe and agent can communicate, adjust the blackfire agent soc
 
 * To use the command-line client, download it for your host platform via the blackfire.io website (see [installation instructions](https://blackfire.io/docs/up-and-running/installation#installation-instructions) for the client for each platform). For basic command-line blackfire.io usage see [the blackfire.io docs](https://blackfire.io/docs/cookbooks/profiling-http). For example, `blackfire curl https://d8git.ddev.site` provides a link to a call graph of the functions which were called to build the page.
 * To use the Google Chrome extension, see [blackfire chrome integration](https://blackfire.io/docs/integrations/chrome) and install the Chrome extension.
-* There's also a [firefox extension](https://blackfire.io/docs/integrations/firefox) and of course Blackfire.io is capable of many other things. 
+* There's also a [firefox extension](https://blackfire.io/docs/integrations/firefox) and of course Blackfire.io is capable of many other things.
 
 
 ### Basic Usage


### PR DESCRIPTION
In trying to get blackfire working, it wasn't obvious to me that the blackfire.agent_socket needed to get overridden and added to a custom php.ini file as outlined by the DDEV docs. Because of the way the current blackfire README was worded, I assumed that the php/blackfire.ini would automatically get pulled in.

This PR updates the README to try to make it more obvious that there is a manual step required, and links to the DDEV docs on how to create a custom php.ini.