### PR TITLE
Use explicit links to service container name for drud/ddev#1897

### DIFF
--- a/docker-compose-services/mysql/docker-compose.mysql.yaml
+++ b/docker-compose-services/mysql/docker-compose.mysql.yaml
@@ -24,7 +24,11 @@ services:
         source: "."
         target: "/mnt/ddev_config"
     # Optionally send startup flags.
-    # command: --sql_mode="" 
+    # command: --sql_mode=""
+  web:
+    links:
+    - mysql:mysql
+
 # Names our volume
 volumes:
   mysql-db:

--- a/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
+++ b/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
@@ -23,6 +23,9 @@ services:
     - ddev-global-cache:/mnt/ddev-global-cache
 
   web:
+    links:
+    - php:php
     healthcheck:
       # Use "true" as the healthcheck to ignore its result
       test: ["CMD", "true"]
+


### PR DESCRIPTION
drud/ddev#1897 points out an issue where if more than one project has a container of the same name, docker may route traffic unpredictably. A couple of the ddev-contrib recipes did not have the required links: stanza to work around this.