### PR TITLE
RabbitMQ service example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ General information on how to do additional services and some additional example
 * [PostgreSQL](docker-compose-services/postgres/)
 * [Elasticsearch](docker-compose-services/elasticsearch)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
+* [RabbitMQ](docker-compose-services/rabbitmq)
 * [TYPO3 Solr Integration](docker-compose-services/typo3-solr)
 
 ## .ddev/web-build/Dockerfile examples to customize web container

--- a/docker-compose-services/rabbitmq/README.md
+++ b/docker-compose-services/rabbitmq/README.md
@@ -1,30 +1,33 @@
-## RabbitMQ
+# RabbitMQ
 
 This enables a RabbitMQ service container that can be used by other containers on the same network and the host machine itself.
 
-### Installation
+## Installation
 
 1. Copy [docker-compose.rabbitmq.yaml](docker-compose.rabbitmq.yaml) to your project
 2. Copy the directory [rabbitmq-build](rabbitmq-build) to your project.
 
 The [rabbitmq-build](rabbitmq-build) directory contains the enabled plugins, these are required for having a functioning RabbitMQ service, as the container would otherwise stop itself shortly after starting. The plugins themselves are what enables the management UI and the graphs within it.
 
-### Configuration
+## Configuration
 
-From within the container, the RabbitMQ container is reached at hostname: rabbitmq, port: 5672, so the server URL might be `amqp://rabbitmq:15672`. 
+From within the container, the RabbitMQ container is reached at hostname: rabbitmq, port: 5672, so the server URL might be `amqp://rabbitmq:15672`.
 
 For more details check the connection section below.
 
-### Connection
+## Connection
 
 RabbitMQ is accessible from the host machine itself as well as between the containers on the same network, and comes with a nice management UI for ease of use.
 
-__Important:__ If you need to run multiple ddev sites that use this RabbitMQ service, you will have to alter the ports per site in the [docker-compose.rabbitmq.yaml](docker-compose.rabbitmq.yaml). 
+__Important:__ If you need to run multiple ddev sites that use this RabbitMQ service, you will have to alter the ports per site in the [docker-compose.rabbitmq.yaml](docker-compose.rabbitmq.yaml).
 
-#### Management UI
+### Management UI
+
 It can be accessed through `http://<DDEV_SITENAME>.ddev.site:15672` on the host machine.
 
-#### AMQP protocol access
+### AMQP protocol access
+
 You can access the RabbitMQ service through it's AMQP protocol two ways:
+
 * From the host machine: `amqp://<DDEV_SITENAME>.ddev.site:5672`
-* From containers on the same network: `amqp://rabbitmq:15672`
+* From docker containers on the same docker network (ddev_default): `amqp://rabbitmq:15672`

--- a/docker-compose-services/rabbitmq/README.md
+++ b/docker-compose-services/rabbitmq/README.md
@@ -23,7 +23,7 @@ __Important:__ If you need to run multiple ddev sites that use this RabbitMQ ser
 
 ### Management UI
 
-It can be accessed through `http://<DDEV_SITENAME>.ddev.site:15672` on the host machine.
+The management UI can be accessed through `http://<DDEV_SITENAME>.ddev.site:15672` on the host machine. Username "rabbitmq", password "rabbitmq".
 
 ### AMQP protocol access
 
@@ -31,3 +31,5 @@ You can access the RabbitMQ service through it's AMQP protocol two ways:
 
 * From the host machine: `amqp://<DDEV_SITENAME>.ddev.site:5672`
 * From docker containers on the same docker network (ddev_default): `amqp://rabbitmq:15672`
+
+**Originally by [@Graloth](https://github.com/Graloth)**

--- a/docker-compose-services/rabbitmq/README.md
+++ b/docker-compose-services/rabbitmq/README.md
@@ -19,6 +19,8 @@ For more details check the connection section below.
 
 RabbitMQ is accessible from the host machine itself as well as between the containers on the same network, and comes with a nice management UI for ease of use.
 
+__Important:__ If you need to run multiple ddev sites that use this RabbitMQ service, you will have to alter the ports per site in the [docker-compose.rabbitmq.yaml](docker-compose.rabbitmq.yaml). 
+
 #### Management UI
 It can be accessed through `http://<DDEV_SITENAME>.ddev.site:15672` on the host machine.
 

--- a/docker-compose-services/rabbitmq/README.md
+++ b/docker-compose-services/rabbitmq/README.md
@@ -1,0 +1,28 @@
+## RabbitMQ
+
+This enables a RabbitMQ service container that can be used by other containers on the same network and the host machine itself.
+
+### Installation
+
+1. Copy [docker-compose.rabbitmq.yaml](docker-compose.rabbitmq.yaml) to your project
+2. Copy the directory [rabbitmq-build](rabbitmq-build) to your project.
+
+The [rabbitmq-build](rabbitmq-build) directory contains the enabled plugins, these are required for having a functioning RabbitMQ service, as the container would otherwise stop itself shortly after starting. The plugins themselves are what enables the management UI and the graphs within it.
+
+### Configuration
+
+From within the container, the RabbitMQ container is reached at hostname: rabbitmq, port: 5672, so the server URL might be `amqp://rabbitmq:15672`. 
+
+For more details check the connection section below.
+
+### Connection
+
+RabbitMQ is accessible from the host machine itself as well as between the containers on the same network, and comes with a nice management UI for ease of use.
+
+#### Management UI
+It can be accessed through `http://<DDEV_SITENAME>.ddev.site:15672` on the host machine.
+
+#### AMQP protocol access
+You can access the RabbitMQ service through it's AMQP protocol two ways:
+* From the host machine: `amqp://<DDEV_SITENAME>.ddev.site:5672`
+* From containers on the same network: `amqp://rabbitmq:15672`

--- a/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
+++ b/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
@@ -1,0 +1,26 @@
+version: '3.6'
+services:
+  rabbitmq:
+    container_name: ddev-${DDEV_SITENAME}-rabbitmq
+    hostname: ${DDEV_SITENAME}-rabbitmq
+    image: "rabbitmq:3-management"
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+    environment:
+      - RABBITMQ_ERLANG_COOKIE=SWQOKODSQALRPCLNMEQG
+      - RABBITMQ_DEFAULT_USER=rabbitmq
+      - RABBITMQ_DEFAULT_PASS=rabbitmq
+      - RABBITMQ_DEFAULT_VHOST=/
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - "./rabbitmq-build/enabled_plugins:/etc/rabbitmq/enabled_plugins"
+      - ".:/mnt/ddev_config"
+  web:
+    links:
+      - rabbitmq:rabbitmq
+volumes:
+  rabbitmq:
+    name: "${DDEV_SITENAME}-rabbitmq"

--- a/docker-compose-services/rabbitmq/rabbitmq-build/enabled_plugins
+++ b/docker-compose-services/rabbitmq/rabbitmq-build/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management, rabbitmq_management_visualiser].


### PR DESCRIPTION
Adds a RabbitMQ service example with readme explaining the basics of how to connect to it.

We've tested this in our local ddev environments and it works fine, though if you need to run multiple ddev sites with this service, you will have to alter the ports so they do not interfere with each-other.