### PR TITLE
TYPO3 Solr Configuration Setup

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,25 @@
+{
+
+  // These rules mostly come from mkdocs rules
+  // https://github.com/mkdocs/mkdocs/blob/master/.markdownlintrc
+
+  // Enable all markdownlint rules
+  "default": true,
+
+  // Fine with long lines, editor can wrap
+  "line-length": false,
+
+  "MD004": { "style": "consistent" },
+
+  // Set Ordered list item prefix to "ordered" (use 1. 2. 3. not 1. 1. 1.)
+  "MD029": { "style": "ordered" },
+
+  // Set list indent level to 4 which Python-Markdown requires
+  "MD007": { "indent": 4 },
+
+  // Fenced code blocks do not need language spec
+  "MD040": false,
+
+  // Exclude code block style
+  "MD046": false
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ General information on how to do additional services and some additional example
 * [PostgreSQL](docker-compose-services/postgres/)
 * [Elasticsearch](docker-compose-services/elasticsearch)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
+* [TYPO3 Solr Integration](docker-compose-services/typo3-solr)
 
 ## .ddev/web-build/Dockerfile examples to customize web container
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# ddev-contrib
-Contrib space for DDEV-Local services, tools, snippets, approaches
+# ddev-contrib: Contrib for DDEV-Local
+
+Contrib space for DDEV-Local services, tools, snippets, approaches.
 
 ## config.yaml hook examples
 

--- a/docker-compose-services/blackfire/README.md
+++ b/docker-compose-services/blackfire/README.md
@@ -2,9 +2,9 @@
 
 Blackfire.io is a profiler for PHP sites, it will help you find out what your code is doing, showing where most of the execution time is spent. It's a successor or competitor to older profiling tools like XHProf. It consists of three parts:
 
-- the probe (Already installed in ddev by default)
-- the agent (Added as an additional service in docker-compose.blackfire.yaml)
-- the client (Installed and configured by you on your host, or any computer)
+1. the probe (Already installed in ddev by default)
+2. the agent (Added as an additional service in docker-compose.blackfire.yaml)
+3. the client (Installed and configured by you on your host, or any computer)
 
 ## The Probe
 

--- a/docker-compose-services/blackfire/README.md
+++ b/docker-compose-services/blackfire/README.md
@@ -1,4 +1,4 @@
-## Blackfire.io Integration for DDEV-Local
+# Blackfire.io Integration for DDEV-Local
 
 Blackfire.io is a profiler for PHP sites, it will help you find out what your code is doing, showing where most of the execution time is spent. It's a successor or competitor to older profiling tools like XHProf. It consists of three parts:
 
@@ -6,25 +6,24 @@ Blackfire.io is a profiler for PHP sites, it will help you find out what your co
 - the agent (Added as an additional service in docker-compose.blackfire.yaml)
 - the client (Installed and configured by you on your host, or any computer)
 
-### The Probe
+## The Probe
 
 The probe is a PHP module which is already installed on a default DDEV setup.
 
-### The Agent
+## The Agent
 
 The agent is provided as docker image by blackfire. Add it to your setup via the provided [docker-compose.blackfire.yaml](docker-compose.blackfire.yaml). Make sure to edit the `BLACKFIRE_SERVER_ID` and `BLACKFIRE_SERVER_TOKEN` environment variables set there.
 
 To make sure the probe and agent can communicate, you must override
 the blackfire agent socket in a custom PHP config file ([docs](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#providing-custom-php-configuration-phpini)). Place the provided [php/blackfire.ini](php/blackfire.ini) in .ddev/php and will work fine; it contains`blackfire.agent_socket = tcp://blackfire:8707`
 
-### The Client
+## The Client
 
 * To use the command-line client, download it for your host platform via the blackfire.io website (see [installation instructions](https://blackfire.io/docs/up-and-running/installation#installation-instructions) for the client for each platform). For basic command-line blackfire.io usage see [the blackfire.io docs](https://blackfire.io/docs/cookbooks/profiling-http). For example, `blackfire curl https://d8git.ddev.site` provides a link to a call graph of the functions which were called to build the page.
 * To use the Google Chrome extension, see [blackfire chrome integration](https://blackfire.io/docs/integrations/chrome) and install the Chrome extension.
 * There's also a [firefox extension](https://blackfire.io/docs/integrations/firefox) and of course Blackfire.io is capable of many other things.
 
-
-### Basic Usage
+## Basic Usage
 
 * Make sure the server information is configured in the docker-compose.blackfire.yaml
 * Make sure your blackfire client is configured with client keys.

--- a/docker-compose-services/elasticsearch/README.md
+++ b/docker-compose-services/elasticsearch/README.md
@@ -1,27 +1,26 @@
-## Elasticsearch
+# Elasticsearch
 
 Using official Elasticsearch container [elasticsearch](https://hub.docker.com/_/elasticsearch).
 
-### Installation
+## Installation
 
-1. Copy [docker-compose-elasticsearch.yaml](docker-compose-elasticsearch.yaml) to your project
+Copy [docker-compose-elasticsearch.yaml](docker-compose-elasticsearch.yaml) to your project's .ddev folder.
 
-### Configuration
+## Configuration
 
-From within the container, the elasticsearch container is reached at hostname: elasticsearch, port: 9200, so the server URL might be `http://elasticsearch:9200`. 
+From within the container, the elasticsearch container is reached at hostname: elasticsearch, port: 9200, so the server URL might be `http://elasticsearch:9200`.
 
-### Connection
+## Connection
 
 You can access the Elasticsearch server directly from the host for debugging purposes by visiting `http://<DDEV_STENAME>.ddev.site:9200`
 
-### Memory Limit
+## Memory Limit
 
 This configuration limits memory usage to 512mb. This should be enough for most projects, but if your `elasticsearch` service stops with no obvious reason, increase your docker max memory or/and the service max memory.  
 
 You can use `ddev logs -s elasticsearch` to investigate what the elasticsearch daemon has been up to, or if you have a RAM-related crash.
 
-### Additional Resources
+## Additional Resources
 
 * There are two related answers to the [Stack Overflow question](https://stackoverflow.com/questions/54575785/how-can-i-use-an-elasticsearch-add-on-container-service-with-ddev) on ddev and Elasticsearch.
 * @juampynr's Lullabot [article on Drupal 8 and Elasticsearch](https://www.lullabot.com/articles/indexing-content-from-drupal-8-to-elasticsearch) is helpful for Drupal users.
-

--- a/docker-compose-services/mongodb/README.md
+++ b/docker-compose-services/mongodb/README.md
@@ -1,26 +1,30 @@
-## MongoDB
+# MongoDB
 
-This simple  create 2 new containers, one for MongoDB and one for Mongo Express. 
+This simple recipe creates two new containers, one for MongoDB and one for Mongo Express.
 
-Based on [MongoDb from Docker Hub](https://hub.docker.com/_/mongo?tab=description#-via-docker-stack-deploy-or-docker-compose), [ddev custom compose files](https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/) and [API Platform tutorial](https://api-platform.com/docs/core/mongodb/#enabling-mongodb-support)
+Based on [MongoDb from Docker Hub](https://hub.docker.com/_/mongo?tab=description#-via-docker-stack-deploy-or-docker-compose), [ddev custom compose files](https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/) and [API Platform tutorial](https://api-platform.com/docs/core/mongodb/#enabling-mongodb-support).
 
 It's a first try, contributions to improve it are welcome!
 
 I'm using it on a Symfony 4 app with API Platform.
 
 Steps to follow:
-- Install Php extension, see the [example .ddev/web-build/Dockerfile](Dockerfile).
-- Add extra file [docker-compose.mongo.yaml](docker-compose.mongo.yaml)
-- Require the [Doctrine MongoDB ODM bundle](https://github.com/doctrine/DoctrineMongoDBBundle)
 
-`ddev composer req doctrine/mongodb-odm-bundle:^4.0.0@beta doctrine/mongodb-odm:^2.0.0@beta`
-- In your application `.env`, set the connection string:
-```
-MONGODB_URL=mongodb://db:db@mongo:27017
-MONGODB_DB=api
-```
+1. Install Php extension, see the [example .ddev/web-build/Dockerfile](Dockerfile).
 
-Mongo Express will be accessible from `<site>.ddev.site:8081`
+2. Add extra file [docker-compose.mongo.yaml](docker-compose.mongo.yaml)
+
+3. Require the [Doctrine MongoDB ODM bundle](https://github.com/doctrine/DoctrineMongoDBBundle)
+    `ddev composer require doctrine/mongodb-odm-bundle:^4.0.0@beta doctrine/mongodb-odm:^2.0.0@beta`
+
+4. In your application `.env`, set the connection string:
+
+    ```
+    MONGODB_URL=mongodb://db:db@mongo:27017
+    MONGODB_DB=api
+    ```
+
+Mongo Express will now be accessible from `<site>.ddev.site:8081`
 
 Caveats:
 

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -1,6 +1,6 @@
-## Using Old PHP Versions (pre-php5.6)
+# Using Old PHP Versions (pre-php5.6)
 
-It's not uncommon to need to be able to run a site that has been neglected for years or decades, often for upgrading, migrating, copying, or archiving purposes. But normally there are just too many errors and problems with these very old sites to get them to run with more recent PHP versions. And the oldest PHP version that ddev directly supports is PHP 5.6. 
+It's not uncommon to need to be able to run a site that has been neglected for years or decades, often for upgrading, migrating, copying, or archiving purposes. But normally there are just too many errors and problems with these very old sites to get them to run with more recent PHP versions. And the oldest PHP version that ddev directly supports is PHP 5.6.
 
 However, there are images of older PHP versions on hub.docker.com and we can use them as third-party services to get the behavior we need, which is usually just being able to *look* at a site.
 
@@ -14,13 +14,13 @@ If you're just kicking the tires, you can use a Drupal 4.7 version with `git clo
 
 ## ddev config
 
-*  `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=10.1` sets up your project
+* `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=10.1` sets up your project
 
 If your docroot is not the default, make sure to set it correctly in the .ddev/config.yaml.
 
 Using Apache is more likely to be compatible with older projects, as is the use of older MariaDB. And we use project type 'php' so that ddev is not tempted to update settings files.
 
-## Copy the files from [.ddev](.ddev) into your project's .ddev. 
+## Copy the files from [.ddev](.ddev) into your project's .ddev
 
 For example `cp -r .ddev/* /path/to/your/repo/.ddev`
 
@@ -40,23 +40,21 @@ Get your database dump and load it into the 'db' database. Use `ddev import-db` 
 
 If older databases have `TYPE=MyISAM` in the table creation stanzas, that will need to be edited out. However, it may be possible to configure MariaDB in the .ddev/mysql directory to provide MyISAM.
 
-
 ## Configure the database settings for your project
 
 ddev is taking no responsiblity for your settings files because you have `type: php`, so you'll need to configure your settings files. For example, on a Drupal 4.7 site, you'll need to add `$db_url = 'mysql://db:db@db/db';` to the sites/default/settings.php file. Don't forget that the *hostname* is 'db', not 'localhost' as often defaulted on many installers. (User/password/database are also 'db'.)
 
-
-Now, if you're paranoid, do a `ddev restart` (probably unnecessary) and begin to debug the problems you've uncovered. 
+Now, if you're paranoid, do a `ddev restart` (probably unnecessary) and begin to debug the problems you've uncovered.
 
 The site you've set up can probably be used as a migration source, can be archived, converted to html with a sitesucker, etc.
 
 ## Options
 
-You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev/docker-compose.php.yaml), you can easily use 5.3, 5.4, or 5.5. 
+You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev/docker-compose.php.yaml), you can easily use 5.3, 5.4, or 5.5.
 
 ## Caveats
 
-* OK, you know that these PHP versions are long out of support and this recipe is provided only to help you resurrect and port or hibernate an old site, not for presentation or production purposes. 
+* OK, you know that these PHP versions are long out of support and this recipe is provided only to help you resurrect and port or hibernate an old site, not for presentation or production purposes.
 * You definitely may have to do more than listed here to get your particular site going.
 * MariaDB 10.1 may not be an old enough database version for you.
 * I haven't experimented with getting PHP4 to work. Please provide a PR to this recipe if you get it to work.

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -26,7 +26,7 @@ When using multiple project with PostgreSQL support, remember to update your `do
 ```
     ports:
       - <EXTERNAL_PORT>:5432
-``` 
+```
 
 ### Import / Export
 
@@ -58,9 +58,11 @@ CREATE EXTENSION IF NOT EXISTS `postgis`;
 Typo3 CMS supports PostgreSQL natively, but the Typo3 Installer has issues with the default `db` database because the `postgis` extension is enabled per default.
 
 You will need to disable the extension before the installation:
+
 ```
 DROP EXTENSION postgis CASCADE;
 ```
+
 It’s safe to re-enable `postgis` after the installation is complete.
 
 ### TODO

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -36,7 +36,7 @@ Resources:
 10. Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
 11. Click "Index Queue" module under "Apache Solr" and
 
-   * Click the checkbox to initialize all pages.
+    * Click the checkbox to initialize all pages.
     * Queue all pages for indexing
     * "Index now" as needed to create the index.
 

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -40,9 +40,9 @@ Resources:
    
 At this point you should have the core_en core populated with an index. 
 
-Visit http://<project>.ddev.site:8983/solr to use the Solr admin dashboard. If you visit the "Core Admin" and choose "core_en" to see statistics about indexed documents, etc.
+Visit `http://<project>.ddev.site:8983/solr` to use the Solr admin dashboard. If you visit the "Core Admin" and choose "core_en" to see statistics about indexed documents, etc.
 
 Now revisit the [EXT:Solr docs](https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/Index.html)  for help with specific configuration, including templating for quality indexing, etc.
 
-When everything is working, consider enabling the `- solrdata:/var/solr` line in .ddev/docker-compose.solr.yaml so you'll have persistent Solr data.
+When everything is working, consider enabling the `- solrdata:/var/solr` line in .ddev/docker-compose.solr.yaml so you'll have persistent Solr data. If the docker volume accidentally already had data in it, then stop the project and delete the volume with `docker rm ddev-<project>_solrdata` before you restart.
 

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -14,5 +14,35 @@ Resources:
 
 1. Add the solr extension to your project: `ddev composer require apache-solr-for-typo3/solr`
 2. In the "Extensions" module deactivate and then re-activate the "Apache Solr for TYPO3" module to make sure that its database tables get installed.
+3. Copy [docker-compose.solr.yaml](docker-compose.solr.yaml) to your project's .ddev folder.
+4. If you want your solr data to be persistent across `ddev restart`, then uncomment the `- solrdata:/var/solr` line in docker-compose.solr.yaml. The comments there explain what you have to do if you want to start over. It's recommended to wait to uncomment that until you have everything else working.
+5. Copy the default Solr configuration from Ext:Solr to ddev:
+    * `mkdir -p .ddev/solr`
+    * `cp -r public/typo3conf/ext/solr/Resources/Private/Solr/* .ddev/solr`
+    * You will have `configsets`, `cores`, `solr.xml` and `zoo.cfg` in .ddev/solr.
+6. `ddev start` will bring up the new solr container.
+   * Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
+7. On the TYPO3 backend "Sites" module, choose your site
+   * Make sure that on the "General" tab a full URL is specified for "Entry Point". Just using "/" here results in a failure of the extension.
+   * On the "Solr" tab (far right) set "Host" to "solr" (NOT the default "localhost")
+   * On the "Languages" tab configure a Corename at the bottom of the page ("English" selected on the right-hand select widget will result in "core_en" being selected.)
+   * Save configuration
+8. On the "Template" module, edit your site/page and 
+   * Choose "Info/Modify" in the select widget at the top of the pane
+   * Click "Edit the whole template record" at the bottom. 
+   * Click the "Includes" tab"
+   * Add "Search - Base Configuration (solr)" and "Search - Default Stylesheets (solr)" to the "Selected Items" pane and save.
+9. "Flush all caches" using the lightning bolt icon on top of the screen.
+10. Click "Index Queue" module under "Apache Solr" and 
+   * Click the checkbox to initialize all pages. 
+   * Queue all pages for indexing
+   * "Index now" as needed to create the index.
+   
+At this point you should have the core_en core populated with an index. 
 
+Visit http://<project>.ddev.site:8983/solr to use the Solr admin dashboard. If you visit the "Core Admin" and choose "core_en" to see statistics about indexed documents, etc.
+
+Now revisit the [EXT:Solr docs](https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/Index.html)  for help with specific configuration, including templating for quality indexing, etc.
+
+When everything is working, consider enabling the `- solrdata:/var/solr` line in .ddev/docker-compose.solr.yaml so you'll have persistent Solr data.
 

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -1,0 +1,18 @@
+## TYPO3-specific Apache Solr Integration for DDEV-Local
+
+Although ddev has [documented generic Solr support](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr) it is as simple as possible, and supports only a single core named "dev". 
+
+The TYPO3 extension assumes a different approach and a slightly different Solr image. 
+
+These instructions were tested with TYPO3 LTS v9.5.
+
+Resources:
+* ApacheSolrForTypo3 EXT:Solr [docs (master)](https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/)
+* [typo3solr/ext-solr](https://hub.docker.com/r/typo3solr/ext-solr/) Solr image on hub.docker.com.
+* [typo3solr Slack Channel](https://typo3.slack.com/messages/ext-solr/)  (request your invite for TYPO3 Slack at https://forger.typo3.org/slack)
+* [Original Stack Overflow Tutorial](https://stackoverflow.com/questions/51479399/how-to-set-up-solr-server-for-typo3-using-ddev) that this is based on.
+
+1. Add the solr extension to your project: `ddev composer require apache-solr-for-typo3/solr`
+2. In the "Extensions" module deactivate and then re-activate the "Apache Solr for TYPO3" module to make sure that its database tables get installed.
+
+

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -20,8 +20,7 @@ Resources:
     * `mkdir -p .ddev/solr`
     * `cp -r public/typo3conf/ext/solr/Resources/Private/Solr/* .ddev/solr`
     * You will have `configsets`, `cores`, `solr.xml` and `zoo.cfg` in .ddev/solr.
-6. `ddev start` will bring up the new solr container.
-   * Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
+6. `ddev restart` will bring up the new solr container.
 7. On the TYPO3 backend "Sites" module, choose your site
    * Make sure that on the "General" tab a full URL is specified for "Entry Point". Just using "/" here results in a failure of the extension.
    * On the "Solr" tab (far right) set "Host" to "solr" (NOT the default "localhost")
@@ -33,7 +32,8 @@ Resources:
    * Click the "Includes" tab"
    * Add "Search - Base Configuration (solr)" and "Search - Default Stylesheets (solr)" to the "Selected Items" pane and save.
 9. "Flush all caches" using the lightning bolt icon on top of the screen.
-10. Click "Index Queue" module under "Apache Solr" and 
+10. Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
+11. Click "Index Queue" module under "Apache Solr" and 
    * Click the checkbox to initialize all pages. 
    * Queue all pages for indexing
    * "Index now" as needed to create the index.

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -1,15 +1,16 @@
-## TYPO3-specific Apache Solr Integration for DDEV-Local
+# TYPO3-specific Apache Solr Integration for DDEV-Local
 
-Although ddev has [documented generic Solr support](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr) it is as simple as possible, and supports only a single core named "dev". 
+Although ddev has [documented generic Solr support](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr) it is as simple as possible, and supports only a single core named "dev".
 
-The TYPO3 extension assumes a different approach and a slightly different Solr image. 
+The TYPO3 extension assumes a different approach and a slightly different Solr image.
 
 These instructions were tested with TYPO3 LTS v9.5.
 
 Resources:
+
 * ApacheSolrForTypo3 EXT:Solr [docs (master)](https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/)
 * [typo3solr/ext-solr](https://hub.docker.com/r/typo3solr/ext-solr/) Solr image on hub.docker.com.
-* [typo3solr Slack Channel](https://typo3.slack.com/messages/ext-solr/)  (request your invite for TYPO3 Slack at https://forger.typo3.org/slack)
+* [typo3solr Slack Channel](https://typo3.slack.com/messages/ext-solr/)  (request your invite for TYPO3 Slack at <https://forger.typo3.org/slack)>
 * [Original Stack Overflow Tutorial](https://stackoverflow.com/questions/51479399/how-to-set-up-solr-server-for-typo3-using-ddev) that this is based on.
 
 1. Add the solr extension to your project: `ddev composer require apache-solr-for-typo3/solr`
@@ -26,23 +27,23 @@ Resources:
    * On the "Solr" tab (far right) set "Host" to "solr" (NOT the default "localhost")
    * On the "Languages" tab configure a Corename at the bottom of the page ("English" selected on the right-hand select widget will result in "core_en" being selected.)
    * Save configuration
-8. On the "Template" module, edit your site/page and 
+8. On the "Template" module, edit your site/page and
    * Choose "Info/Modify" in the select widget at the top of the pane
-   * Click "Edit the whole template record" at the bottom. 
+   * Click "Edit the whole template record" at the bottom.
    * Click the "Includes" tab"
    * Add "Search - Base Configuration (solr)" and "Search - Default Stylesheets (solr)" to the "Selected Items" pane and save.
 9. "Flush all caches" using the lightning bolt icon on top of the screen.
 10. Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
-11. Click "Index Queue" module under "Apache Solr" and 
-   * Click the checkbox to initialize all pages. 
-   * Queue all pages for indexing
-   * "Index now" as needed to create the index.
-   
-At this point you should have the core_en core populated with an index. 
+11. Click "Index Queue" module under "Apache Solr" and
+
+* Click the checkbox to initialize all pages.
+    * Queue all pages for indexing
+    * "Index now" as needed to create the index.
+
+At this point you should have the core_en core populated with an index.
 
 Visit `http://<project>.ddev.site:8983/solr` to use the Solr admin dashboard. If you visit the "Core Admin" and choose "core_en" to see statistics about indexed documents, etc.
 
 Now revisit the [EXT:Solr docs](https://docs.typo3.org/p/apache-solr-for-typo3/solr/master/en-us/Index.html)  for help with specific configuration, including templating for quality indexing, etc.
 
 When everything is working, consider enabling the `- solrdata:/var/solr` line in .ddev/docker-compose.solr.yaml so you'll have persistent Solr data. If the docker volume accidentally already had data in it, then stop the project and delete the volume with `docker rm ddev-<project>_solrdata` before you restart.
-

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -35,7 +35,8 @@ Resources:
 9. "Flush all caches" using the lightning bolt icon on top of the screen.
 10. Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
 11. Click "Index Queue" module under "Apache Solr" and
-12. Click the checkbox to initialize all pages.
+
+   * Click the checkbox to initialize all pages.
     * Queue all pages for indexing
     * "Index now" as needed to create the index.
 

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -35,8 +35,7 @@ Resources:
 9. "Flush all caches" using the lightning bolt icon on top of the screen.
 10. Click the "Apache Solr" "Info" module on the left and choose your site, you should see that it has connected the Apache Solr server.
 11. Click "Index Queue" module under "Apache Solr" and
-
-* Click the checkbox to initialize all pages.
+12. Click the checkbox to initialize all pages.
     * Queue all pages for indexing
     * "Index now" as needed to create the index.
 

--- a/docker-compose-services/typo3-solr/docker-compose.solr.yaml
+++ b/docker-compose-services/typo3-solr/docker-compose.solr.yaml
@@ -3,7 +3,7 @@ version: '3.6'
 services:
   solr:
     container_name: ddev-${DDEV_SITENAME}-solr
-    image: typo3solr/ext-solr:10.0.0
+    image: typo3solr/ext-solr:10.0.1
     restart: "no"
     ports:
       - 8983

--- a/docker-compose-services/typo3-solr/docker-compose.solr.yaml
+++ b/docker-compose-services/typo3-solr/docker-compose.solr.yaml
@@ -1,0 +1,28 @@
+version: '3.6'
+
+services:
+  solr:
+    container_name: ddev-${DDEV_SITENAME}-solr
+    image: typo3solr/ext-solr:10.0.0
+    restart: "no"
+    ports:
+      - 8983
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=8983
+    volumes:
+      - "./solr:/opt/solr/server/solr"
+      # If you want your solr to persist over `ddev stop` and `ddev start` then uncomment the following line
+      # If you uncomment it and want to flush your data you have to `ddev stop` and then
+      # `docker volume rm ddev-<projectname>_solrdata` to destroy it.
+#      - solrdata:/var/solr
+  web:
+    links:
+      - solr:$DDEV_HOSTNAME
+
+volumes:
+  # solrdata is a persistent Docker volume for this project's solr data
+  solrdata:

--- a/docker-compose-snippets/mounting-directory/README.md
+++ b/docker-compose-snippets/mounting-directory/README.md
@@ -1,8 +1,8 @@
-## Mounting a directory into web container
+# Mounting a directory into web container
 
-This simple [docker-compose.mount.yaml](docker-compose.mount.yaml) just mounts a directory from the host into the web container. 
+This simple [docker-compose.mount.yaml](docker-compose.mount.yaml) just mounts a directory from the host into the web container.
 
 Caveats:
 
-* The source directory on the host must be shared via docker. 
-* If the mount should be read-only in the container, add `:ro` to the mount 
+* The source directory on the host must be shared via docker.
+* If the mount should be read-only in the container, add `:ro` to the mount

--- a/docker-compose-snippets/project-communication/README.md
+++ b/docker-compose-snippets/project-communication/README.md
@@ -1,4 +1,4 @@
-## Communicating between two projects
+# Communicating between two projects
 
 There are many reasons to have two independent ddev projects talk with each other, and there are very easy ways to do it:
 
@@ -9,7 +9,7 @@ What some people want, though, is a third option, *HTTP or HTTPS routed through 
 
 This [docker-compose.project2.yaml](docker-compose.project2.yaml) is intended to be put in project1/.ddev/, and  then it will be able to `curl https://project1.ddev.site`, or do anything else that's going through the router (http or https exposed ports)
 
-### Resources
+## Resources
 
 * [Stack Overflow question on communication between projects](https://stackoverflow.com/questions/51710272/communication-between-two-ddev-projects)
 * [Migrating from Drupal 6 to Drupal 8 Like a Boss](https://dev.acquia.com/blog/migrating-drupal-6-drupal-8-boss) demonstrates option 1 in the context of a Drupal migration activity.

--- a/hook-examples/import-db-if-empty/README.md
+++ b/hook-examples/import-db-if-empty/README.md
@@ -1,17 +1,16 @@
-## Import a sql dump if database is empty
+# Import a sql dump if database is empty
 
-**Use case:** 
+## Use case
 
-You want to import a sql dump automatically on `ddev start` if the database is empty so the user gets a full setup of the project. 
-Another case would be, that you are running `composer install` on `post-start` hook, but your composer setup requires some data from the database (e.g. on a TYPO3 setup). 
+You want to import a sql dump automatically on `ddev start` if the database is empty so the user gets a full setup of the project.
+Another case would be, that you are running `composer install` on `post-start` hook, but your composer setup requires some data from the database (e.g. on a TYPO3 setup).
 `ddev start` will fail, as composer expects the data to be there and `ddev import-db` will also fail, as it needs the db container to be started, so it will simply run `ddev start` again.
 
-**Solution:**
- 
+## Solution
+
 Run a bash script like [import-if-empty.sh](import-if-empty.sh) on a `post-start` hook, which looks for a table in the database that should always be there and imports a database dump if check fails.
 
 The hook setup might look like this; adjust the path to the script. If it's in your code repository, the script will mounted into `/var/www/html/<relative_path>`.
-
 
 ```
 hooks:

--- a/recipes/bludit-cms/README.md
+++ b/recipes/bludit-cms/README.md
@@ -1,9 +1,10 @@
 # Install [Bludit CMS](https://www.bludit.com/) with DDEV
 
-# What is Bludit?
+## What is Bludit
+
 Bludit is an open source content managment system. Its a flat file cms which means that you dont need a database for it, bludit saves everything in the folders. You can read more about that, in the Bludit Documentation for the [Folder Structure](https://docs.bludit.com/en/developers/folder-structure).
 
-# Installation
+## Installation
 
 Installation is the same as for any general-purpose PHP or HTML project, you get the code and then use `ddev config` and `ddev start`.
 
@@ -18,6 +19,5 @@ Clone the git repository for bludit: `git clone https://github.com/bludit/bludit
 * `ddev start`
 * Visit the selected URL (like `https://bludit.ddev.site`) to install Bludit.
 * To see complete ddev project information, use `ddev describe`.
-
 
 ## Original Author: [@crydotsnake](https://twitter.com/crydotsnake)

--- a/recipes/cronjob/README.md
+++ b/recipes/cronjob/README.md
@@ -1,6 +1,6 @@
-# enable cronjob on start or on demand
+# Enable cronjob on start or on demand
 
 1. Install the `ddev cron` custom command [commands/web/cron](commands/web/cron) in your .ddev/commands/web directory. Make sure that it's executable (`chmod +x .ddev/commands/web/cron`).
-1. Place [config.cron.yml](config.cron.yml) in the .ddev directory (or add it to your .ddev/config.yaml); it will run the custom `ddev cron` command on project start, which will run a cronjob for typo3 scheduler:run on every minute. 
+2. Place [config.cron.yml](config.cron.yml) in the .ddev directory (or add it to your .ddev/config.yaml); it will run the custom `ddev cron` command on project start, which will run a cronjob for typo3 scheduler:run on every minute.
 
 To run cron on demand, run `ddev cron`.

--- a/recipes/laravel/README.md
+++ b/recipes/laravel/README.md
@@ -1,12 +1,15 @@
 # Install [Laravel](https://laravel.com/) with DDEV
 
-## What is Laravel?
+## What is Laravel
+
 [Laravel](https://laravel.com/) is a web application framework with expressive, elegant syntax. We’ve already laid the foundation — freeing you to create without sweating the small things.
 
 ## Install Laravel
+
 In order to create a Laravel project follow the installation instructions [here](https://laravel.com/docs/master/installation).
 
 A normal composer build can be done with
+
 ```
 mkdir newsite
 cd newsite
@@ -16,6 +19,7 @@ ddev config --docroot=public && ddev start
 ```
 
 ## Setup .env file
+
 Laravel uses its `.env` file to hold its config. An example file can be found in the root of the repo as `.env.example`.
 
 **NOTE:** If you have used the composer installer `ddev composer create --prefer-dist laravel/laravel` then the `.env` file will have been automatically created for you. This will also set the application key so there is no need to run `php artisan key:generate`.
@@ -34,8 +38,8 @@ DB_PASSWORD=db
 These would change if you set the db credentials to something else in `.ddev/docker-compose.yaml`
 
 ## Start up
+
 * `ddev start`
 * `ddev ssh`
 * Run `php artisan key:generate` this sets the application key via [artisan](https://laravel.com/docs/master/artisan)
 * Visit the site URL (like `https://laravel.ddev.site`) and you should see the default welcome page
-

--- a/recipes/proxy/README.md
+++ b/recipes/proxy/README.md
@@ -9,17 +9,17 @@ There are 4 basic things that need to work in a behind-proxy ddev environment:
 3. The docker client needs to be configured for proxy, in ~/.docker/config.json. This will cause containers to be launched with the correct environment variables like HTTP_PROXY and friends already set up. See this [example config.json](config.json). Note that your mileage may vary and you may have to do more than change the proxy addresses given here.
 4. Individual images may need to be set up to make apt work inside them. This is optional, because if you do your apt-get work at container build time (in a .ddev/web-build/Dockerfile) then everything works using the host configuration. See the [example .ddev/web-build/Dockerfile](Dockerfile).
 
-
 ## Lab-testing a proxied environment
 
-I used Parallels on macOS for the test lab. 
+I used Parallels on macOS for the test lab.
+
 * Created a Parallels VM proxy server with a simple tiny Ubuntu 18.04 server running [tinyproxy](https://tinyproxy.github.io/), which was shockingly simple to install and configure (`apt-get install tinyproxy`), very small configuration changes ([example /etc/tinyproxy/tinyproxy.conf](tinyproxy.conf)). I'll call this machine "proxy".
 * Added an additional "host-only" interface in Parallels and added it to the proxy VM
-* Used an existing (different) Ubuntu 18.04 Parallels VM as the ddev/docker environment and added the host only interface to it.  I'll call this machine "workstation". 
+* Used an existing (different) Ubuntu 18.04 Parallels VM as the ddev/docker environment and added the host only interface to it.  I'll call this machine "workstation".
 * Turned off the primary network interface in the workstation, so it had no direct network connectivity, verified that ping of internet addresses failed.
 * Configured the workstation VM with system-wide proxy settings using the regular Ubuntu network setting GUI (in this case HTTP/HTTPS proxies using 10.37.129.4).
 * Configured the Firefox browser on "workstation" to use the system-configured proxy and verified that it could now operate.
-* Verified that curl against internet https locations now worked on the "workstation". 
+* Verified that curl against internet https locations now worked on the "workstation".
 * Configured the docker server as in step 2 above, and verified that `docker pull ubuntu` now worked on "workstation" using the proxy.
 * Configured the docker client as in step 3 above and verified that proxy setup was now right in the container by `ddev start`, `ddev ssh`, and using curl inside the container against an HTTPS website.
 * Added the .ddev/web-build/Dockerfile from step 4 into the ddev project on the "workstation" and `ddev start`, then `ddev ssh` and `sudo apt-get update` and saw the update happen successfully, all using the proxy.

--- a/recipes/redaxo-cms/README.md
+++ b/recipes/redaxo-cms/README.md
@@ -1,10 +1,10 @@
 # Install [REDAXO CMS](https://redaxo.org) with DDEV
 
-## What is REDAXO?
+## What is REDAXO
 
-[REDAXO](https://redaxo.org) is an open source content managment system devleoped by the German web agency  [Yakamara](https://www.yakamara.de/). 
+[REDAXO](https://redaxo.org) is an open source content managment system devleoped by the German web agency  [Yakamara](https://www.yakamara.de/).
 
-REDAXO is for people who love the flexibility of a content managment system; you have easy control of your code and also of the content that you want to create. 
+REDAXO is for people who love the flexibility of a content managment system; you have easy control of your code and also of the content that you want to create.
 
 ## Install REDAXO code and submodules
 
@@ -24,5 +24,4 @@ In general, REDAXO setup is exactly the same as any other generic PHP project, e
 * Configure site and database settings. (Database name is `db`, mysql host is `db`, database username is `db`, and password is `db`)
 * Complete setup
 * To see complete ddev project information, use `ddev describe`.
-
 ## Original Author: [@crydotsnake](https://twitter.com/crydotsnake)

--- a/recipes/redaxo-cms/README.md
+++ b/recipes/redaxo-cms/README.md
@@ -24,4 +24,5 @@ In general, REDAXO setup is exactly the same as any other generic PHP project, e
 * Configure site and database settings. (Database name is `db`, mysql host is `db`, database username is `db`, and password is `db`)
 * Complete setup
 * To see complete ddev project information, use `ddev describe`.
+
 ## Original Author: [@crydotsnake](https://twitter.com/crydotsnake)


### PR DESCRIPTION
This PR (see [README](https://github.com/rfay/ddev-contrib/blob/25b4700a93da3edd00ecfaedadba6e75a2b0de43/docker-compose-services/typo3-solr/README.md)) builds on the [Stack Overflow](https://stackoverflow.com/questions/51479399/how-to-set-up-solr-server-for-typo3-using-ddev) answer for TYPO3 Solr, with more detailed explanation of what to do.