### PR TITLE
Add elastichq service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ General information on how to do additional services and some additional example
 * [Blackfire.io](docker-compose-services/blackfire/)
 * [PostgreSQL](docker-compose-services/postgres/)
 * [Elasticsearch](docker-compose-services/elasticsearch)
+* [Elastichq](docker-compose-services/elastichq)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [RabbitMQ](docker-compose-services/rabbitmq)
 * [TYPO3 Solr Integration](docker-compose-services/typo3-solr)

--- a/docker-compose-services/elastichq/README.md
+++ b/docker-compose-services/elastichq/README.md
@@ -1,14 +1,21 @@
-The purpose of this service is to enable a GUI for viewing the data that is inside the elastricsearch service.
+# ElasticHQ
 
-## Elasticsearch
+This recipe adds an ElasticHQ container to a project.
 
-This elasticHQ service requires that you have an elasticsearch service available for it to link to.
+This will allow you to have a graphical interface for browsing data in your Elasticsearch server.
 
-### Installation
+## Requirements
 
-1. Copy [docker-compose.elastichq.yaml](docker-compose.elastichq.yaml) to your project
+Elastic HQ requires that there is a container within the project that has a working instance of Elasticsearch running for it to connect to.
 
-### Connection
+## Configuration
 
-You can access the ElasticHQ GUI directly from the host by visiting `http://<DDEV_SITENAME>.ddev.site:5000`
+If your Elasticsearch server is not available on `http://elasticsearch:9200`, then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
 
+* Change `HQ_DEFAULT_URL` to the url your Elasticsearch server is available at.
+
+## Installation
+
+* Copy `docker-compose.elastichq.yaml` to the `.ddev` folder of your project.
+* Start (or restart) DDEV to have the service initialized: `ddev start`
+* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:5000`

--- a/docker-compose-services/elastichq/README.md
+++ b/docker-compose-services/elastichq/README.md
@@ -6,11 +6,11 @@ This will allow you to have a graphical interface for browsing data in your Elas
 
 ## Requirements
 
-Elastic HQ requires that there is a container within the project that has a working instance of Elasticsearch running for it to connect to.
+Elastic HQ requires that there is a container within the project that has a working instance of Elasticsearch running for it to connect to. This is based on the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
 
 ## Configuration
 
-If your Elasticsearch server is not available on `http://elasticsearch:9200`, then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
+If your Elasticsearch server is not available inside the web container at `http://elasticsearch:9200`, then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
 
 * Change `HQ_DEFAULT_URL` to the url your Elasticsearch server is available at.
 
@@ -19,3 +19,5 @@ If your Elasticsearch server is not available on `http://elasticsearch:9200`, th
 * Copy `docker-compose.elastichq.yaml` to the `.ddev` folder of your project.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
 * Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:5000`
+
+**Contributed by [@Graloth](https://github.com/Graloth)**

--- a/docker-compose-services/elastichq/README.md
+++ b/docker-compose-services/elastichq/README.md
@@ -10,14 +10,14 @@ Elastic HQ requires that there is a container within the project that has a work
 
 ## Configuration
 
-If your Elasticsearch server is not available inside the web container at `http://elasticsearch:9200`, then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
+If your Elasticsearch server is not available inside the elastichq container at `http://elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
 
-* Change `HQ_DEFAULT_URL` to the url your Elasticsearch server is available at.
+* Change `HQ_DEFAULT_URL` to the url your Elasticsearch server is available at within the elastichq container.
 
 ## Installation
 
 * Copy `docker-compose.elastichq.yaml` to the `.ddev` folder of your project.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
-* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:5000`
+* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:5000` or via https at `https://<DDEV_SITENAME>.ddev.site:5443`.
 
 **Contributed by [@Graloth](https://github.com/Graloth)**

--- a/docker-compose-services/elastichq/README.md
+++ b/docker-compose-services/elastichq/README.md
@@ -1,0 +1,14 @@
+The purpose of this service is to enable a GUI for viewing the data that is inside the elastricsearch service.
+
+## Elasticsearch
+
+This elasticHQ service requires that you have an elasticsearch service available for it to link to.
+
+### Installation
+
+1. Copy [docker-compose.elastichq.yaml](docker-compose.elastichq.yaml) to your project
+
+### Connection
+
+You can access the ElasticHQ GUI directly from the host by visiting `http://<DDEV_SITENAME>.ddev.site:5000`
+

--- a/docker-compose-services/elastichq/docker-compose.elastichq.yaml
+++ b/docker-compose-services/elastichq/docker-compose.elastichq.yaml
@@ -1,0 +1,21 @@
+version: '3.6'
+services:
+  elastichq:
+    container_name: ddev-${DDEV_SITENAME}-elastichq
+    hostname: ${DDEV_SITENAME}-elastichq
+    image: elastichq/elasticsearch-hq
+    restart: always
+    ports:
+      - "5000"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=5000
+      - HQ_DEFAULT_URL=http://elasticsearch:9200
+    volumes:
+      - ".:/mnt/ddev_config"
+  elasticsearch:
+    links:
+      - elastichq:elastichq

--- a/docker-compose-services/elastichq/docker-compose.elastichq.yaml
+++ b/docker-compose-services/elastichq/docker-compose.elastichq.yaml
@@ -12,7 +12,8 @@ services:
       com.ddev.approot: $DDEV_APPROOT
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=5000
+      - HTTP_EXPOSE=5000:5000
+      - HTTPS_EXPOSE=5443:5000
       - HQ_DEFAULT_URL=http://elasticsearch:9200
     volumes:
       - ".:/mnt/ddev_config"


### PR DESCRIPTION
Adds an elastichq service example that integrates with an existing elasticsearch service within the DDEV project, allowing you to have a GUI for the contents of your elasticsearch server.

I made this service as I needed a proper way to confirm that my data was properly stored on the elasticsearch server without having to run a bunch of terminal commands.