### PR TITLE
Adds a redis service example

### DIFF
--- a/docker-compose-services/redis/docker-compose.redis.yaml
+++ b/docker-compose-services/redis/docker-compose.redis.yaml
@@ -1,0 +1,20 @@
+version: '3.6'
+services:
+  redis:
+    container_name: ddev-${DDEV_SITENAME}-redis
+    hostname: ${DDEV_SITENAME}-redis
+    image: redis:4
+    restart: always
+    ports:
+      - 6379
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=6379
+    volumes:
+      - ".:/mnt/ddev_config"
+  web:
+    links:
+      - redis:redis

--- a/docker-compose-services/rediscommander/docker-compose.rediscommander.yaml
+++ b/docker-compose-services/rediscommander/docker-compose.rediscommander.yaml
@@ -1,0 +1,23 @@
+version: '3.6'
+services:
+  rediscommander:
+    container_name: ddev-${DDEV_SITENAME}-rediscommander
+    hostname: ${DDEV_SITENAME}-rediscommander
+    image: rediscommander/redis-commander
+    restart: always
+    ports:
+      - "1358"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=1358
+      - REDIS_PORT=6379
+      - REDIS_HOST=redis
+      - PORT=1358
+    volumes:
+      - ".:/mnt/ddev_config"
+  redis:
+    links:
+      - rediscommander:rediscommander


### PR DESCRIPTION
This will allow your web container to use redis.

It still needs a readme, which I haven't gotten around to writing, as it can be helpful for people to know how they actually are able to connect to the redis server (for example, how to do it in Drupal).