### PR TITLE
Adds an example of a redis-commander service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ General information on how to do additional services and some additional example
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [RabbitMQ](docker-compose-services/rabbitmq)
 * [redis](docker-compose-services/redis)
+* [redis-commander](docker-compose-services/redis-commander)
 * [TYPO3 Solr Integration](docker-compose-services/typo3-solr)
 
 ## .ddev/web-build/Dockerfile examples to customize web container

--- a/docker-compose-services/redis-commander/README.md
+++ b/docker-compose-services/redis-commander/README.md
@@ -24,3 +24,5 @@ If your redis server is not available on host `redis` on port `6379`, then you n
 ## Notes
 
 This service example is made to work with the redis service example out-of-the-box, as such you might need to do some additional tweaking to either your redis server or this service if you are using a different redis server.
+
+**Contributed by [@Graloth](https://github.com/Graloth)**

--- a/docker-compose-services/redis-commander/README.md
+++ b/docker-compose-services/redis-commander/README.md
@@ -1,0 +1,26 @@
+# Redis Commander
+
+This recipe adds a Redis Commander container to a project.
+
+This will allow you to have a graphical interface for browsing data in your Redis server.
+
+## Requirements
+
+Redis Commander requires that there is a container within the project that has a working instance of Redis running for it to connect to.
+
+## Configuration
+
+If your redis server is not available on host `redis` on port `6379`, then you need to edit `docker-compose.redis-commander.yaml` and edit the following environment variables:
+
+* Change `REDIS_PORT` to the port your redis server is available at.
+* Change `REDIS_HOST` to the hostname your redis server is available at.
+
+## Installation
+
+* Copy `docker-compose.redis-commander.yaml` to the `.ddev` folder of your project.
+* Start (or restart) DDEV to have the service initialized: `ddev start`
+* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:1358`
+
+## Notes
+
+This service example is made to work with the redis service example out-of-the-box, as such you might need to do some additional tweaking to either your redis server or this service if you are using a different redis server.

--- a/docker-compose-services/redis-commander/README.md
+++ b/docker-compose-services/redis-commander/README.md
@@ -19,7 +19,7 @@ If your redis server is not available on host `redis` on port `6379`, then you n
 
 * Copy `docker-compose.redis-commander.yaml` to the `.ddev` folder of your project.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
-* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:1358`
+* Access your redis-commander UI at `http://<DDEV_STENAME>.ddev.site:1358` or `https://<DDEV_SITENAME>.ddev.site:1359`
 
 ## Notes
 

--- a/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
+++ b/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
@@ -1,0 +1,23 @@
+version: '3.6'
+services:
+  redis-commander:
+    container_name: ddev-${DDEV_SITENAME}-redis-commander
+    hostname: ${DDEV_SITENAME}-redis-commander
+    image: rediscommander/redis-commander
+    restart: always
+    ports:
+      - 1358
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=1358
+      - REDIS_PORT=6379
+      - REDIS_HOST=redis
+      - PORT=1358
+    volumes:
+      - ".:/mnt/ddev_config"
+  redis:
+    links:
+      - redis-commander:redis-commander

--- a/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
+++ b/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
@@ -13,6 +13,7 @@ services:
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=1358
+      - HTTPS_EXPOSE=1359:1358
       - REDIS_PORT=6379
       - REDIS_HOST=redis
       - PORT=1358


### PR DESCRIPTION
This is a service example with a readme for adding a GUI client to your redis server.

I've added a proper readme to this example, as I have more experience with it.

This service is tested to work with the redis service example from PR #36 which is also my recommended way to run redis.