### PR TITLE
Direct to correct drush.yaml file

### DIFF
--- a/recipes/drupal8-multisite/README.md
+++ b/recipes/drupal8-multisite/README.md
@@ -65,7 +65,7 @@ Now we have to do a DDEV specific thing. Trying to be helpful, it creates a glob
 
 We want to disable that option. However, the file is DDEV generated, so we can't just comment the line out, it may get regenerated. We need to remove the auto-generation marker lines as well. We can make this file empty.
 
-1. Edit `web/sites/all/drush/drush.yml` and delete all content including comments
+1. Edit `drush/drush.yml` and delete all content including comments
 2. Explicitly check the file in to git, if you use git (it has to be explicit, as DDEV also creates a local `.gitignore` file)
 
 ## Prepare example umami site


### PR DESCRIPTION
- [ ] multisite PR maintenance
- [ ] Use disable_settings_management: true
- [ ] Remove reference to drush' @self.site.yml
- [ ] Better example of site settings.php file
- [ ] drush.yml explanation of emptying it is in the wrong place
- [ ] root: in the files in drush/sites is all wrong (has root: /var/www/html/web/basic, should be root: /var/www/html/web/sites/basic)