### PR TITLE
Adds an example of selenium service

### DIFF
--- a/docker-compose-services/selenium/README.md
+++ b/docker-compose-services/selenium/README.md
@@ -1,0 +1,15 @@
+# Selenium in DDEV  
+
+Running selenium for e.g Codeception tests can be quite handy.
+
+To include this to your own project you can do following:
+
+```
+$ cp docker-compose.selenium.yaml /path/to/your/project/.ddev/docker-composer.selenium.yaml
+$ cd /path/to/your/project/
+$ ddev start # or ddev restart (depending on the state of the project)
+```
+
+Now you have a selenium with a chrome headless browser node running in your ddev project.
+
+To see how to use it with Codeception, you can take a loot at (https://dev.to/tomasnorre/codeception-ddev-selenium-docker-36kk)[https://dev.to/tomasnorre/codeception-ddev-selenium-docker-36kk]

--- a/docker-compose-services/selenium/README.md
+++ b/docker-compose-services/selenium/README.md
@@ -12,4 +12,6 @@ $ ddev start # or ddev restart (depending on the state of the project)
 
 Now you have a selenium with a chrome headless browser node running in your ddev project.
 
+You can check that the Selenum is running and which browser is included by checking (http://localhost:4444/grid/console)[http://localhost:4444/grid/console], where you can also see which configuration is used.
+
 To see how to use it with Codeception, you can take a loot at (https://dev.to/tomasnorre/codeception-ddev-selenium-docker-36kk)[https://dev.to/tomasnorre/codeception-ddev-selenium-docker-36kk]

--- a/docker-compose-services/selenium/docker-compose.selenium.yaml
+++ b/docker-compose-services/selenium/docker-compose.selenium.yaml
@@ -1,0 +1,18 @@
+version: '3.6'
+services:
+  selenium-hub:
+    image: selenium/hub:3.141.59-20200326
+    container_name: ddev-${DDEV_SITENAME}-selenium-hub
+    ports:
+      - "4444:4444"
+
+  chrome:
+    image: selenium/node-chrome:3.141.59-20200326
+    container_name: ddev-${DDEV_SITENAME}-chrome
+    volumes:
+      - /dev/shm:/dev/shm
+    depends_on:
+      - selenium-hub
+    environment:
+      - HUB_HOST=selenium-hub
+      - HUB_PORT=4444


### PR DESCRIPTION
This is a small example on how selenium can be added to ddev to e.g. run Codeception tests locally. 