### PR TITLE
Bump elasticsearch to the latest in the example

### DIFF
--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -3,12 +3,13 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:5.6
+    image: elasticsearch:7.6.1
     ports:
       - "9200"
       - "9300"
     environment:
       - cluster.name=docker-cluster
+      - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - VIRTUAL_HOST=$DDEV_HOSTNAME

--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -13,7 +13,8 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - VIRTUAL_HOST=$DDEV_HOSTNAME
-      - HTTP_EXPOSE=9200
+      - HTTP_EXPOSE=9200:9200
+      - HTTPS_EXPOSE=9201:9200
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
As for instance http://drupal.org/project/elasticsearch_connector isn't compatible with the current example