### PR TITLE
Improve postgres example by mentioning client installation

### DIFF
--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -39,7 +39,7 @@ Example `config.yaml` hooks configuration to automatically import/export the `db
 
 ```
 # Add psql to your webserver
-webimage_extra_packages: [postgresql-11]
+webimage_extra_packages: [postgresql-client]
 
 # Automatically import and export PostreSQL database on ddev start and stop
 hooks:

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -38,6 +38,10 @@ Two new `ddev` commands are provided:
 Example `config.yaml` hooks configuration to automatically import/export the `db` table:
 
 ```
+# Add psql to your webserver
+webimage_extra_packages: [postgresql-11]
+
+# Automatically import and export PostreSQL database on ddev start and stop
 hooks:
   pre-stop:
     - exec-host: ddev pgsql_export


### PR DESCRIPTION
The standard ddev-webserver comes with PHP pgsql extension enabled, but lacks the psql client. This little fix to your config file will install the  extra webimage package for postgresql-11. This is especially important when you run Drush for a Drupal site on a PostgreSQL database, which will fail if the psql command isn't available.