### PR TITLE
Make all persistent volumes have same name as service so they can be removed

### DIFF
--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -27,4 +27,3 @@ services:
 
 volumes:
   elasticsearch:
-    name: "${DDEV_SITENAME}-elasticsearch"

--- a/docker-compose-services/mongodb/docker-compose.mongo.yaml
+++ b/docker-compose-services/mongodb/docker-compose.mongo.yaml
@@ -8,7 +8,7 @@ services:
 
     volumes:
       - type: "volume"
-        source: mongo-database
+        source: mongo
         target: "/data/db"
         volume:
           nocopy: true
@@ -43,5 +43,4 @@ services:
       - mongo:mongo
 
 volumes:
-  mongo-database:
-    name: "${DDEV_SITENAME}-mongo"
+  mongo:

--- a/docker-compose-services/postgres/docker-compose.postgres.yaml
+++ b/docker-compose-services/postgres/docker-compose.postgres.yaml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_DB=db
     volumes:
       - type: "volume"
-        source: postgres-database
+        source: postgres
         target: "/var/lib/postgresql/data"
         volume:
           nocopy: true
@@ -27,5 +27,4 @@ services:
       - postgres:postgres
 
 volumes:
-  postgres-database:
-    name: "${DDEV_SITENAME}-postgres"
+  postgres:

--- a/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
+++ b/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
@@ -23,4 +23,3 @@ services:
       - rabbitmq:rabbitmq
 volumes:
   rabbitmq:
-    name: "${DDEV_SITENAME}-rabbitmq"

--- a/docker-compose-services/typo3-solr/docker-compose.solr.yaml
+++ b/docker-compose-services/typo3-solr/docker-compose.solr.yaml
@@ -18,11 +18,12 @@ services:
       # If you want your solr to persist over `ddev stop` and `ddev start` then uncomment the following line
       # If you uncomment it and want to flush your data you have to `ddev stop` and then
       # `docker volume rm ddev-<projectname>_solrdata` to destroy it.
-#      - solrdata:/var/solr
+#      - solr:/var/solr
   web:
     links:
       - solr:$DDEV_HOSTNAME
 
 volumes:
-  # solrdata is a persistent Docker volume for this project's solr data
-  solrdata:
+  # solr is a persistent Docker volume for this project's solr data
+  # the volume will be named ddev-<project>_solr
+  solr:


### PR DESCRIPTION
ddev v1.14+ will have the ability to delete volumes associated with a service when `ddev delete` or `ddev stop -R` is done. But it relies on the naming convention. As a result, we should avoid free-form naming.