### PR TITLE
Add a git-exclude command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 
 * [Dump and deploy SQL from/to remote servers](custom-commands/dump-and-deploy-db/)
 * [Fetch Production DB from remote server](custom-commands/fetchproductiondb/)
+* [Exclude ddev directory from git: git-exclude](custom-commands/git-exclude)
 
 ## Additional services added via docker-compose.\<service\>.yaml
 

--- a/custom-commands/dump-and-deploy-db/README.md
+++ b/custom-commands/dump-and-deploy-db/README.md
@@ -36,4 +36,4 @@ It was planned to create siblings for these commands in the form of `dump-files`
 
 ![dump-db](dump-db-example.png)
 
-**Original submission from [@jonaseberle](https://github.com/jonaseberle)**
+**Contributed by [@jonaseberle](https://github.com/jonaseberle)**

--- a/custom-commands/git-exclude/README.md
+++ b/custom-commands/git-exclude/README.md
@@ -1,0 +1,7 @@
+# Excludes ddev from Git Custom Command (ddev git-exclude)
+
+Copy the [git-exclude](./git-exclude) command to the .ddev/commands/host/ directory.
+
+now you can run `ddev git-exclude` and avoid tracking the ddev files in git.
+
+**Contributed by [@pcambra](https://github.com/pcambra) and [@facine](https://github.com/facine)**

--- a/custom-commands/git-exclude/README.md
+++ b/custom-commands/git-exclude/README.md
@@ -1,6 +1,6 @@
 # Excludes ddev from Git Custom Command (ddev git-exclude)
 
-Copy the [git-exclude](./git-exclude) command to the .ddev/commands/host/ directory.
+Copy the [git-exclude](./git-exclude) command to the .ddev/commands/host/ directory or the global ~/.ddev/commands/host directory (to make it work for all projects).
 
 now you can run `ddev git-exclude` and avoid tracking the ddev files in git.
 

--- a/custom-commands/git-exclude/git-exclude
+++ b/custom-commands/git-exclude/git-exclude
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+## Description: Exclude ddev generated files from the project repo
+## Usage: git-exclude
+
+case $OSTYPE in
+  linux-gnu | "darwin"* )
+    if [ $DDEV_PROJECT_TYPE == "drupal7" ]; then
+      grep -qxF ".ddev" .git/info/exclude || echo ".ddev" >> .git/info/exclude
+      grep -qxF "${DDEV_DOCROOT}/sites/default/.gitignore" .git/info/exclude || echo "${DDEV_DOCROOT}/sites/default/.gitignore" >> .git/info/exclude
+    elif [ $DDEV_PROJECT_TYPE == "drupal8" ] || [ $DDEV_PROJECT_TYPE == "drupal9" ]; then
+      grep -qxF ".ddev" .git/info/exclude || echo ".ddev" >> .git/info/exclude
+      grep -qxF "drush/.gitignore" .git/info/exclude || echo "drush/.gitignore" >> .git/info/exclude
+      grep -qxF "${DDEV_DOCROOT}/sites/default/.gitignore" .git/info/exclude || echo "${DDEV_DOCROOT}/sites/default/.gitignore" >> .git/info/exclude
+    fi
+    ;;
+esac


### PR DESCRIPTION
Often we find ourselves using ddev in environments where not necessarily everyone uses it and thus might not be appropriate to check the files into the repository.
Here's an initial version of a command that excludes all ddev files automatically.