### PR TITLE
Change mongodb extension installation instructions

### DIFF
--- a/docker-compose-services/mongodb/Dockerfile
+++ b/docker-compose-services/mongodb/Dockerfile
@@ -1,7 +1,0 @@
-# This is a Dockerfile for use with the ddev-webserver image
-# It should be in .ddev/web-build/Dockerfile
-# and then you can expand on it.
-ARG BASE_IMAGE=drud/ddev-webserver:v1.9.1
-FROM $BASE_IMAGE
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y php-mongodb
-# You can add additional Dockerfile build activities here.

--- a/docker-compose-services/mongodb/README.md
+++ b/docker-compose-services/mongodb/README.md
@@ -10,7 +10,7 @@ I'm using it on a Symfony 4 app with API Platform.
 
 Steps to follow:
 
-1. Install Php extension, see the [example .ddev/web-build/Dockerfile](Dockerfile).
+1. Install Php extension using [webimage_extra_packages](https://ddev.readthedocs.io/en/stable/users/extend/customizing-images/) config option: `webimage_extra_packages: [php-mongodb]`
 
 2. Add extra file [docker-compose.mongo.yaml](docker-compose.mongo.yaml)
 


### PR DESCRIPTION
resolves drud/ddev-contrib#69

Installing MongoDB php extension via `webimage_extra_packages` config option instead of altering Dockerfile
