### PR TITLE
Use stderr redirection to make "Import a sql dump if database is empty" quiet on start

### DIFF
--- a/hook-examples/import-db-if-empty/import-if-empty.sh
+++ b/hook-examples/import-db-if-empty/import-if-empty.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-# Use a table that should exist in your database instead of "mytable"
-if ! mysql -e 'SELECT * FROM mytable;' db >/dev/null 2>&1; then
-  echo 'loading db'
+# Set TABLETOFIND to a table which should exist in a loaded database
+TABLETOFIND=users
+
+if ! mysql -e "SELECT * FROM ${TABLETOFIND};" db >/dev/null 2>&1; then
+  echo "loading database since table named '${TABLETOFIND}' was not found."
   # This assumes the db.sql.gz is in the root of your repository, but
   # adjust as necessary.
-  gzip -dc /var/www/html/db.sql.gz | mysql db
+  gzip -dc /var/www/html/.tarballs/d8composer.sql.gz | mysql db
+else
+  echo "NOT loading database; it already exists; table '${TABLETOFIND}' was found."
 fi

--- a/hook-examples/import-db-if-empty/import-if-empty.sh
+++ b/hook-examples/import-db-if-empty/import-if-empty.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use a table that should exist in your database instead of "mytable"
-if ! mysql -e 'SELECT * FROM mytable;' db > /dev/null; then
+if ! mysql -e 'SELECT * FROM mytable;' db 2>/dev/null; then
   echo 'loading db'
   # This assumes the db.sql.gz is in the root of your repository, but
   # adjust as necessary.

--- a/hook-examples/import-db-if-empty/import-if-empty.sh
+++ b/hook-examples/import-db-if-empty/import-if-empty.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use a table that should exist in your database instead of "mytable"
-if ! mysql -e 'SELECT * FROM mytable;' db 2>/dev/null; then
+if ! mysql -e 'SELECT * FROM mytable;' db >/dev/null 2>&1; then
   echo 'loading db'
   # This assumes the db.sql.gz is in the root of your repository, but
   # adjust as necessary.


### PR DESCRIPTION
* Updated script to redirect the stderr to /dev/null to avoid
showing an error on screen when target table is not found.