### PR TITLE
Simplify mongodb, use HTTPS_EXPOSE for access to mongo-express, fixes #69

### DIFF
--- a/docker-compose-services/mongodb/Dockerfile
+++ b/docker-compose-services/mongodb/Dockerfile
@@ -1,7 +1,0 @@
-# This is a Dockerfile for use with the ddev-webserver image
-# It should be in .ddev/web-build/Dockerfile
-# and then you can expand on it.
-ARG BASE_IMAGE=drud/ddev-webserver:v1.9.1
-FROM $BASE_IMAGE
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y php-mongodb
-# You can add additional Dockerfile build activities here.

--- a/docker-compose-services/mongodb/README.md
+++ b/docker-compose-services/mongodb/README.md
@@ -4,13 +4,11 @@ This simple recipe creates two new containers, one for MongoDB and one for Mongo
 
 Based on [MongoDb from Docker Hub](https://hub.docker.com/_/mongo?tab=description#-via-docker-stack-deploy-or-docker-compose), [ddev custom compose files](https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/) and [API Platform tutorial](https://api-platform.com/docs/core/mongodb/#enabling-mongodb-support).
 
-It's a first try, contributions to improve it are welcome!
-
 I'm using it on a Symfony 4 app with API Platform.
 
 Steps to follow:
 
-1. Install Php extension, see the [example .ddev/web-build/Dockerfile](Dockerfile).
+1. Install php-mongo extension by adding `webimage_extra_packages: [php-mongodb]` to your .ddev/config.yaml.
 
 2. Add extra file [docker-compose.mongo.yaml](docker-compose.mongo.yaml)
 
@@ -24,9 +22,11 @@ Steps to follow:
     MONGODB_DB=api
     ```
 
-Mongo Express will now be accessible from `<site>.ddev.site:8081`
+Mongo Express will now be accessible from `https://<site>.ddev.site:8081`
 
 Caveats:
 
-* you can't define custom MongoDB configuration
-* you can't use `ddev import-db`
+* You can't define custom MongoDB configuration with this current setup.
+* You can't use `ddev import-db` to import to mongo.
+
+**Contributed by [@wtfred](https://github.com/wtfred)**

--- a/docker-compose-services/mongodb/docker-compose.mongo.yaml
+++ b/docker-compose-services/mongodb/docker-compose.mongo.yaml
@@ -3,25 +3,23 @@ version: '3.6'
 services:
   mongo:
     container_name: ddev-${DDEV_SITENAME}-mongo
-
     image: mongo:4.0
-
     volumes:
-      - type: "volume"
-        source: mongo
-        target: "/data/db"
-        volume:
-          nocopy: true
+    - type: "volume"
+      source: mongo
+      target: "/data/db"
+      volume:
+        nocopy: true
     restart: "no"
     ports:
-      - "27017"
+    - "27017"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     environment:
-      - MONGO_INITDB_ROOT_USERNAME=db
-      - MONGO_INITDB_ROOT_PASSWORD=db
-      - MONGO_INITDB_DATABASE=db
+    - MONGO_INITDB_ROOT_USERNAME=db
+    - MONGO_INITDB_ROOT_PASSWORD=db
+    - MONGO_INITDB_DATABASE=db
 
   mongo-express:
     container_name: ddev-${DDEV_SITENAME}-mongo-express
@@ -29,18 +27,23 @@ services:
     restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
+      com.ddev.approot: ${DDEV_APPROOT}
+      com.ddev.platform: ddev
+
     links:
-      - mongo:mongo
+    - mongo:mongo
     ports:
-      - "127.0.0.1:8081:8081"
+    - "8081"
     environment:
-      - ME_CONFIG_MONGODB_ADMINUSERNAME=db
-      - ME_CONFIG_MONGODB_ADMINPASSWORD=db
+      VIRTUAL_HOST: $DDEV_HOSTNAME
+      ME_CONFIG_MONGODB_ADMINUSERNAME: db
+      ME_CONFIG_MONGODB_ADMINPASSWORD: db
+      HTTP_EXPOSE: "8082:8081"
+      HTTPS_EXPOSE: 8081:8081
 
   web:
     links:
-      - mongo:mongo
+    - mongo:mongo
 
 volumes:
   mongo:


### PR DESCRIPTION
As proposed in #69, use simpler technique of getting php-mongo into the web container. Also exposes the mongo-express port in a way that works if more than one project uses it.

@wtfred could you please review this? Thanks!