### PR TITLE
Add recipe for Solr 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ General information on how to do additional services and some additional example
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [Portainer Service for DDEV](docker-compose-services/portainer)
 * [PostgreSQL](docker-compose-services/postgres/)
+* [Solr 4 Integration](docker-compose-services/solr4)  
 * [Solr 5 Integration](docker-compose-services/solr-5)
 * [RabbitMQ](docker-compose-services/rabbitmq)
 * [redis](docker-compose-services/redis)

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -7,7 +7,7 @@ The Solr version used in this recipe is 4.10.4 which is not supported officially
 To enable Solr in your project follow these steps:
 
 1. Create a directory named _solr_ in your project's `.ddev` directory.
-1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev\solr`.
+1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev/solr`.
 1. Copy the [core.properties](core.properties) into `.ddev/solr` and edit it according to your needs.
 1. Create a new directory `.ddev/solr/data`.
 1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev/solr/conf`.

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -8,7 +8,7 @@ To enable Solr in your project follow these steps:
 
 1. Create a directory named _solr_ in your project's `.ddev` directory.
 1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev\solr`.
-1. Copy the [core.properties](core.properties) into `.ddev\solr` and edit it according to your needs.
+1. Copy the [core.properties](core.properties) into `.ddev/solr` and edit it according to your needs.
 1. Create a new directory `.ddev/solr/data`.
 1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev\solr\conf`.
 1. Run `ddev start`.

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -9,7 +9,7 @@ To enable Solr in your project follow these steps:
 1. Create a directory named _solr_ in your project's `.ddev` directory.
 1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev\solr`.
 1. Copy the [core.properties](core.properties) into `.ddev\solr` and edit it according to your needs.
-1. Create a new directory `.ddev\solr\data`.
+1. Create a new directory `.ddev/solr/data`.
 1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev\solr\conf`.
 1. Run `ddev start`.
 

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -15,7 +15,7 @@ To enable Solr in your project follow these steps:
 
 You now have a running Solr instance for your project. To get the URL for the instance run `ddev describe`.
 
-By default the Solr core is named "dev" and the host is named "solr" so applications running inside the web container will be able to access the Solr service at http://solr:8983.
+By default the Solr core is named "dev" and the host is named "solr" so applications running inside the web container will be able to access the Solr service at `http://solr:8983`.
 
 > **Note**
 >

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -10,7 +10,7 @@ To enable Solr in your project follow these steps:
 1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev\solr`.
 1. Copy the [core.properties](core.properties) into `.ddev/solr` and edit it according to your needs.
 1. Create a new directory `.ddev/solr/data`.
-1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev\solr\conf`.
+1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev/solr/conf`.
 1. Run `ddev start`.
 
 You now have a running Solr instance for your project. To get the URL for the instance run `ddev describe`.

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -1,6 +1,6 @@
 # Solr 4.x
 
-This recipe allows you to configure a Solr server for your project using version 4.
+This recipe allows you to configure a [Solr](https://lucene.apache.org/solr/) server for your project using version 4.
 
 The Solr version used in this recipe is 4.10.4 which is not supported officially anymore.
 
@@ -20,3 +20,7 @@ By default the Solr core is named "dev" and the host is named "solr" so applicat
 > **Note**
 >
 > If you change the name of the core in [core.properties](core.properties) you also need to update the name in [docker-compose.solr.yml](docker-compose.solr.yml), section "services > solr > volumes".
+
+--- 
+
+Special thanks to [Jeff Geerling](https://www.jeffgeerling.com/) for building [Docker images](https://hub.docker.com/r/geerlingguy/solr) using versions of Apache Solr that have been deprecated long time ago.

--- a/docker-compose-services/solr4/README.md
+++ b/docker-compose-services/solr4/README.md
@@ -1,0 +1,22 @@
+# Solr 4.x
+
+This recipe allows you to configure a Solr server for your project using version 4.
+
+The Solr version used in this recipe is 4.10.4 which is not supported officially anymore.
+
+To enable Solr in your project follow these steps:
+
+1. Create a directory named _solr_ in your project's `.ddev` directory.
+1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev\solr`.
+1. Copy the [core.properties](core.properties) into `.ddev\solr` and edit it according to your needs.
+1. Create a new directory `.ddev\solr\data`.
+1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev\solr\conf`.
+1. Run `ddev start`.
+
+You now have a running Solr instance for your project. To get the URL for the instance run `ddev describe`.
+
+By default the Solr core is named "dev" and the host is named "solr" so applications running inside the web container will be able to access the Solr service at http://solr:8983.
+
+> **Note**
+>
+> If you change the name of the core in [core.properties](core.properties) you also need to update the name in [docker-compose.solr.yml](docker-compose.solr.yml), section "services > solr > volumes".

--- a/docker-compose-services/solr4/core.properties
+++ b/docker-compose-services/solr4/core.properties
@@ -1,0 +1,4 @@
+name=dev
+config=solrconfig.xml
+schema=schema.xml
+dataDir=data

--- a/docker-compose-services/solr4/docker-compose.solr.yml
+++ b/docker-compose-services/solr4/docker-compose.solr.yml
@@ -1,0 +1,52 @@
+version: '3.6'
+
+services:
+  # This is the service name used when running ddev commands accepting the
+  # --service flag.
+  solr:
+    # Name of container using standard ddev convention.
+    container_name: ddev-${DDEV_SITENAME}-solr
+    image: geerlingguy/solr:4.10.4
+    restart: "always"
+    # Solr is served from this port inside the container.
+    ports:
+      - 8983
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.site.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # This defines the port the service should be accessible from at
+      # sitename.ddev.site.
+      - HTTP_EXPOSE=8983
+    volumes:
+      # solr core *data* is stored on the 'solr' docker volume
+      # This mount is optional; without it your search index disappears
+      # each time the ddev project is stopped and started.
+      - solr:/var/solr
+
+      # This mounts the conf in .ddev/solr into the container.
+      - ./solr:/opt/solr/example/solr/dev
+
+      - ".:/mnt/ddev_config"
+
+    # Start the server.
+    command: ["/opt/solr/bin/solr", "start", "-p", "8983", "-f"]
+
+    external_links:
+      - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
+
+  # This links the Solr service to the web service defined in the main
+  # docker-compose.yml, allowing applications running inside the web container to
+  # access the Solr service at http://solr:8983
+  web:
+    links:
+      - solr:solr
+volumes:
+  # solr is a persistent Docker volume for solr data
+  # The persistent volume should have the same name as the service so it can be deleted
+  # when the project is deleted.
+  solr:


### PR DESCRIPTION
For a (Drupal) project we needed to integrate _Apache Solr_ version 4 in our DDEV setup.
The recipe shows a simple example on how to run _Solr_ version 4 in DDEV.