### PR TITLE
Update old-php recipe

### DIFF
--- a/docker-compose-services/old_php/.ddev/apache/apache-site.conf
+++ b/docker-compose-services/old_php/.ddev/apache/apache-site.conf
@@ -1,3 +1,5 @@
+# This apache-site.conf goes in .ddev/apache
+# It works against a back-end php-fpm docker container from devilbox
 <VirtualHost *:80>
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =https

--- a/docker-compose-services/old_php/.ddev/apache/apache-site.conf
+++ b/docker-compose-services/old_php/.ddev/apache/apache-site.conf
@@ -1,7 +1,4 @@
 <VirtualHost *:80>
-    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
-    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
-
     RewriteEngine On
     RewriteCond %{HTTP:X-Forwarded-Proto} =https
     RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
@@ -9,96 +6,22 @@
 
     SetEnvIf X-Forwarded-Proto "https" HTTPS=on
 
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
-	<Directory "/var/www/html/">
-  		AllowOverride All
-  		Allow from All
-	</Directory>
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
+    DocumentRoot /var/www/html
+    <Directory "/var/www/html/">
+      AllowOverride All
+      Allow from All
+    </Directory>
 
-	ErrorLog /dev/stdout
-	CustomLog ${APACHE_LOG_DIR}/access.log combined
+    CustomLog /var/log/apache2/access.log combined
 
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
-	# Simple ddev technique to get a phpstatus
-	Alias "/phpstatus" "/var/www/phpstatus.php"
+    # ProxyFCGIBackendType GENERIC seems to be necessary for php5.2
+    ProxyFCGIBackendType GENERIC
+    ProxyPassMatch ^/(.*\.php(/.*)?)$ fcgi://php:9000/var/www/html/$1
+    DirectoryIndex /index.php index.php
 
-    <FilesMatch ".+\.ph(ar|p|tml)$">
-        SetHandler "proxy:fcgi://php:9000"
-    </FilesMatch>
-    <FilesMatch ".+\.phps$">
-        # Deny access to raw php sources by default
-        # To re-enable it's recommended to enable access to the files
-        # only in specific virtual host or directory
-        Require all denied
-    </FilesMatch>
-    # Deny access to files without filename (e.g. '.php')
-    <FilesMatch "^\.ph(ar|p|ps|tml)$">
-        Require all denied
-    </FilesMatch>
+
+    Alias "/phpstatus" "/var/www/phpstatus.php"
+
 </VirtualHost>
 
-<VirtualHost *:443>
-    SSLEngine on
-    SSLCertificateFile /etc/ssl/certs/master.crt
-    SSLCertificateKeyFile /etc/ssl/certs/master.key
-
-    # Workaround from https://mail-archives.apache.org/mod_mbox/httpd-users/201403.mbox/%3C49404A24C7FAD94BB7B45E86A9305F6214D04652@MSGEXSV21103.ent.wfb.bank.corp%3E
-    # See also https://gist.github.com/nurtext/b6ac07ac7d8c372bc8eb
-
-    RewriteEngine On
-    RewriteCond %{HTTP:X-Forwarded-Proto} =https
-    RewriteCond    %{DOCUMENT_ROOT}%{REQUEST_FILENAME} -d
-    RewriteRule    ^(.+[^/])$           https://%{HTTP_HOST}$1/ [redirect,last]
-
-    SetEnvIf X-Forwarded-Proto "https" HTTPS=on
-
-	ServerAdmin webmaster@localhost
-	DocumentRoot /var/www/html
-	<Directory "/var/www/html/">
-  		AllowOverride All
-  		Allow from All
-	</Directory>
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
-
-	ErrorLog /dev/stdout
-	CustomLog ${APACHE_LOG_DIR}/access.log combined
-
-	# For most configuration files from conf-available/, which are
-	# enabled or disabled at a global level, it is possible to
-	# include a line for only one particular virtual host. For example the
-	# following line enables the CGI configuration for this host only
-	# after it has been globally disabled with "a2disconf".
-	#Include conf-available/serve-cgi-bin.conf
-	# Simple ddev technique to get a phpstatus
-	Alias "/phpstatus" "/var/www/phpstatus.php"
-
-    <FilesMatch ".+\.ph(ar|p|tml)$">
-        SetHandler "proxy:fcgi://php:9000"
-    </FilesMatch>
-    <FilesMatch ".+\.phps$">
-        # Deny access to raw php sources by default
-        # To re-enable it's recommended to enable access to the files
-        # only in specific virtual host or directory
-        Require all denied
-    </FilesMatch>
-    # Deny access to files without filename (e.g. '.php')
-    <FilesMatch "^\.ph(ar|p|ps|tml)$">
-        Require all denied
-    </FilesMatch>
-</VirtualHost>
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -63,3 +63,5 @@ You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev
 * OK, you know that these PHP versions are long out of support and this recipe is provided only to help you resurrect and port or hibernate an old site, not for presentation or production purposes.
 * You definitely may have to do more than listed here to get your particular site going.
 * I haven't experimented with getting PHP4 to work. Please provide a PR to this recipe if you get it to work.
+
+**Originally by [@rfay](https://github.com/rfay)**

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -14,7 +14,7 @@ If you're just kicking the tires, you can use a Drupal 4.7 version with `git clo
 
 ## ddev config
 
-* `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=10.1` sets up your project
+* `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=5.5` sets up your project
 
 If your docroot is not the default, make sure to set it correctly in the .ddev/config.yaml.
 
@@ -56,5 +56,4 @@ You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev
 
 * OK, you know that these PHP versions are long out of support and this recipe is provided only to help you resurrect and port or hibernate an old site, not for presentation or production purposes.
 * You definitely may have to do more than listed here to get your particular site going.
-* MariaDB 10.1 may not be an old enough database version for you.
 * I haven't experimented with getting PHP4 to work. Please provide a PR to this recipe if you get it to work.

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -6,6 +6,12 @@ However, there are images of older PHP versions on hub.docker.com and we can use
 
 This recipe was explicitly tested on Drupal 4.7 and 5.x, both from the 2008-2010 timeframe. 5.x installation succeeded with this configuration and PHP 5.3. Drupal 4.7 installation (very manual) succeeeded with PHP 5.2. Another approach which I used initially is to build the site or recover it on an Ubuntu 12.04 VM.
 
+## Architecture
+
+The normal DDEV-Local approach is to run both nginx/apache and php-fpm in the same container. However, it doesn't have to be that way. Here we're using *apache* int he regular ddev-webserver, but we've set the apache config to proxy to a different container, a php container running one of the Devilbox php images.
+
+This means that the `php_version` you have set in your .ddev/config.yaml is irrelevant; the actual PHP version is the one in the Devilbox container.
+
 ## Check out or download the repository and files into a project directory
 
 For example, on a Drupal site you'll want the code and the user-uploaded files from sites/default/files.


### PR DESCRIPTION
The old-php recipe seems to have rotted. I updated it to simplify the apache configuration and switch to using mariadb 5.5 (since we now have it). 

I tested this with php5.2 and 5.3, seemed to be OK against Drupal 4.7