### PR TITLE
Add BROWSERTEST_OUTPUT_BASE_URL to env vars in drupalci-crhomedriver

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -17,5 +17,5 @@ services:
       # - SIMPLETEST_DB=mysql://db:db@db:3306/db
       - SIMPLETEST_BASE_URL=http://web
       - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
-      - BROWSERTEST_OUTPUT_BASE_URL=http://${DDEV_SITENAME}.ddev.site
+      - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
       - MINK_DRIVER_ARGS_WEBDRIVER=["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]

--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -17,4 +17,5 @@ services:
       # - SIMPLETEST_DB=mysql://db:db@db:3306/db
       - SIMPLETEST_BASE_URL=http://web
       - BROWSERTEST_OUTPUT_DIRECTORY=/tmp
+      - BROWSERTEST_OUTPUT_BASE_URL=http://${DDEV_SITENAME}.ddev.site
       - MINK_DRIVER_ARGS_WEBDRIVER=["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox"]}}, "http://chromedriver:9515"]


### PR DESCRIPTION
## Problem

URLs output by phpunit pointing to test artifacts use http://web for the address but should use the URL of the web container so they can be viewed.

## Resolution

This adds the `BROWSERTEST_OUTPUT_BASE_URL` to the environment variables in the web container. Which, phpunit will use when outputting links to saved HTML assets generated during a test run.

Before:

<img width="1186" alt="html 2020-10-22 15-19-22" src="https://user-images.githubusercontent.com/17613/96933029-63a69700-1485-11eb-80a5-5d3f90b11028.png">

After:

<img width="1117" alt="html 2020-10-22 16-41-26" src="https://user-images.githubusercontent.com/17613/96933063-71f4b300-1485-11eb-90b3-12719f1c8be9.png">
