### PR TITLE
Change Portainer port on the host

### DIFF
--- a/docker-compose-services/portainer/README.md
+++ b/docker-compose-services/portainer/README.md
@@ -23,26 +23,39 @@ Portainer is a visual mode for management of containers and networks. Is open-so
 
 ## Connection
 
-Ok, by default you can access to the Portainer interface at the next address from your browser:
+Ok, by default you can access to the Portainer interface at the next addresses from your browser:
 
 ```
-https://projectname.ddev.site:9001
-https://127.0.0.1:9001
+# using http
+http://projectname.ddev.site:9001
+http://127.0.0.1:9001
+
+# or using https
+https://projectname.ddev.site:8001
+https://127.0.0.1:8001
+```
+**Why?** Well, we're setting the mapped ports from Host to Guest just likes this:   
+
+``` 
+environment:
+  HTTP_EXPOSE: "9001:9000"
+  HTTPS_EXPOSE: "8001:9000"
 ```
 
-Cause is the annotated port registered in the config.yaml file. If you want to avoid conflicts, just stop your DDEV-Local network, change the value and relaunch the containers.
+If you want to avoid conflicts in the host side, just stop your DDEV-Local network, changing the value in the former section and relaunch the containers.  
 
-Just do:
+Just do:  
 
 ```
 $ ddev stop
 $ vim docker-compose.portainer.yaml
-ports:
-  - '3434:9000'
-:wq!
+    environment:
+      HTTP_EXPOSE: "3401:9000"
+      HTTPS_EXPOSE: "3501:9000"
+  :wq!
 $ ddev start
 ```
 
-But remember that Portainer always exposes from port 9000, so use this address as destiny in your mapping.
+And remember that Portainer always exposes internally to the ddev network from its port 9000 in the container, so use this address as destiny in your mapping.  
 
 **Contributed by [davidjguru](https://gitlab.com/davidjguru)**, [Drupal Developer](https://www.drupal.org/u/davidjguru) and blogger in [The Russian Lullaby](https://www.therussianlullaby.com/).

--- a/docker-compose-services/portainer/README.md
+++ b/docker-compose-services/portainer/README.md
@@ -26,8 +26,8 @@ Portainer is a visual mode for management of containers and networks. Is open-so
 Ok, by default you can access to the Portainer interface at the next address from your browser:
 
 ```
-https://projectname.ddev.site:9000
-https://127.0.0.1:9000
+https://projectname.ddev.site:9001
+https://127.0.0.1:9001
 ```
 
 Cause is the annotated port registered in the config.yaml file. If you want to avoid conflicts, just stop your DDEV-Local network, change the value and relaunch the containers.
@@ -35,12 +35,12 @@ Cause is the annotated port registered in the config.yaml file. If you want to a
 Just do:
 
 ```
-ddev stop
-vim docker-compose.portainer.yaml
+$ ddev stop
+$ vim docker-compose.portainer.yaml
 ports:
   - '3434:9000'
 :wq!
-ddev start
+$ ddev start
 ```
 
 But remember that Portainer always exposes from port 9000, so use this address as destiny in your mapping.

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -4,8 +4,8 @@ services:
     portainer:
         image: portainer/portainer:latest
         environment:
-          HTTP_EXPOSE: 80:80,8025:8025,9001:9000
-          HTTPS_EXPOSE: 443:80,8026:8025,8001:9000
+          - HTTP_EXPOSE=9001:9000
+          - HTTPS_EXPOSE=8001:9000
         restart:  always
         container_name: ddev-${DDEV_SITENAME}-portainer
         labels:

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -4,8 +4,8 @@ services:
     portainer:
         image: portainer/portainer:latest
         environment:
-          - HTTP_EXPOSE=9001:9000
-          - HTTPS_EXPOSE=8001:9000
+          HTTP_EXPOSE: "9001:9000"
+          HTTPS_EXPOSE: "8001:9000"
         restart:  always
         container_name: ddev-${DDEV_SITENAME}-portainer
         labels:
@@ -19,7 +19,7 @@ services:
         cap_add:
             - SYS_ADMIN
         expose:
-          - '9000'
+          - "9000"
 volumes:
   portainer_data:
 

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -16,8 +16,7 @@ services:
         cap_add:
             - SYS_ADMIN
         ports:
-          - '9000:9000'
-          - '8000:8000'
+          - '9001:9000'
 volumes:
   portainer_data:
 

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -1,25 +1,26 @@
 ---
 version: '3.6'
 services:
-    portainer:
-        image: portainer/portainer:latest
-        environment:
-          HTTP_EXPOSE: "9001:9000"
-          HTTPS_EXPOSE: "8001:9000"
-        restart: "no"
-        container_name: ddev-${DDEV_SITENAME}-portainer
-        labels:
-          com.ddev.site-name: ${DDEV_SITENAME}
-          com.ddev.approot: $DDEV_APPROOT
-        volumes:
-          - /var/run/docker.sock:/var/run/docker.sock
-          - portainer_data:/data
-        external_links:
-          - "ddev-router:${DDEV_HOSTNAME}"
-        cap_add:
-          - SYS_ADMIN
-        expose:
-          - "9000"
+  portainer:
+    image: portainer/portainer:latest
+    expose:
+      - "9000"
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9001:9000
+      - HTTPS_EXPOSE=8001:9000
+    restart: "no"
+    container_name: ddev-${DDEV_SITENAME}-portainer
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - portainer_data:/data
+    external_links:
+      - "ddev-router:${DDEV_HOSTNAME}"
+    cap_add:
+      - SYS_ADMIN
 volumes:
   portainer_data:
 

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -3,6 +3,9 @@ version: '3.6'
 services:
     portainer:
         image: portainer/portainer:latest
+        environment:
+          HTTP_EXPOSE: 80:80,8025:8025,9001:9000
+          HTTPS_EXPOSE: 443:80,8026:8025,8001:9000
         restart:  always
         container_name: ddev-${DDEV_SITENAME}-portainer
         labels:
@@ -15,8 +18,8 @@ services:
             - "ddev-router:${DDEV_HOSTNAME}"
         cap_add:
             - SYS_ADMIN
-        ports:
-          - '9001:9000'
+        expose:
+          - '9000'
 volumes:
   portainer_data:
 

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -6,7 +6,7 @@ services:
         environment:
           HTTP_EXPOSE: "9001:9000"
           HTTPS_EXPOSE: "8001:9000"
-        restart:  always
+        restart: "no"
         container_name: ddev-${DDEV_SITENAME}-portainer
         labels:
           com.ddev.site-name: ${DDEV_SITENAME}
@@ -15,9 +15,9 @@ services:
           - /var/run/docker.sock:/var/run/docker.sock
           - portainer_data:/data
         external_links:
-            - "ddev-router:${DDEV_HOSTNAME}"
+          - "ddev-router:${DDEV_HOSTNAME}"
         cap_add:
-            - SYS_ADMIN
+          - SYS_ADMIN
         expose:
           - "9000"
 volumes:
@@ -27,4 +27,3 @@ networks:
   default:
     external:
       name: ddev_default
-


### PR DESCRIPTION
Change port for the Host in order to avoid conflicts when xdebug is enabled. 
Now uses port 9001, mapping 9001:9000 for Portainer. 