### PR TITLE
Change elasticsearch version from 7.6.1 to 7.10.1

### DIFF
--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:7.6.1
+    image: elasticsearch:7.10.1
     ports:
       - "9200"
       - "9300"


### PR DESCRIPTION
The official elasticsearch dockerhub only lists the tags 7.10.1 and 6.8.13 as supported. When I ran ddev start with tag 7.6.1 I got an error "pulling elasticsearch (elasticsearch:7.6.1)... no matching manifest for linux/arm64/v8 in the manifest list entries". With tag 7.10.1 it worked for me.