### PR TITLE
Minor improvements to typo3-solr

### DIFF
--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -14,8 +14,8 @@ Resources:
 * [Original Stack Overflow Tutorial](https://stackoverflow.com/questions/51479399/how-to-set-up-solr-server-for-typo3-using-ddev) that this is based on.
 
 1. Add the solr extension to your project: `ddev composer require apache-solr-for-typo3/solr`
-2. In the "Extensions" module deactivate and then re-activate the "Apache Solr for TYPO3" module to make sure that its database tables get installed.
-3. Copy [docker-compose.solr.yaml](docker-compose.solr.yaml) to your project's .ddev folder.
+2. Deactivate and then re-activate the "Apache Solr for TYPO3" module to make sure that its database tables get installed: `ddev typo3 extension:deactivate solr && ddev typo3 extension:activate solr`
+3. Copy [docker-compose.solr.yaml](https://raw.githubusercontent.com/drud/ddev-contrib/master/docker-compose-services/typo3-solr/docker-compose.solr.yaml) to your project's .ddev folder.
 4. If you want your solr data to be persistent across `ddev restart`, then uncomment the `- solrdata:/var/solr` line in docker-compose.solr.yaml. The comments there explain what you have to do if you want to start over. It's recommended to wait to uncomment that until you have everything else working.
 5. Copy the default Solr configuration from Ext:Solr to ddev:
     * `mkdir -p .ddev/solr`

--- a/docker-compose-services/typo3-solr/README.md
+++ b/docker-compose-services/typo3-solr/README.md
@@ -15,7 +15,7 @@ Resources:
 
 1. Add the solr extension to your project: `ddev composer require apache-solr-for-typo3/solr`
 2. Deactivate and then re-activate the "Apache Solr for TYPO3" module to make sure that its database tables get installed: `ddev typo3 extension:deactivate solr && ddev typo3 extension:activate solr`
-3. Copy [docker-compose.solr.yaml](https://raw.githubusercontent.com/drud/ddev-contrib/master/docker-compose-services/typo3-solr/docker-compose.solr.yaml) to your project's .ddev folder.
+3. Copy [docker-compose.solr.yaml](docker-compose.solr.yaml) to your project's .ddev folder.
 4. If you want your solr data to be persistent across `ddev restart`, then uncomment the `- solrdata:/var/solr` line in docker-compose.solr.yaml. The comments there explain what you have to do if you want to start over. It's recommended to wait to uncomment that until you have everything else working.
 5. Copy the default Solr configuration from Ext:Solr to ddev:
     * `mkdir -p .ddev/solr`

--- a/docker-compose-services/typo3-solr/docker-compose.solr.yaml
+++ b/docker-compose-services/typo3-solr/docker-compose.solr.yaml
@@ -5,7 +5,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-solr
     image: typo3solr/ext-solr:10.0.1
     restart: "no"
-    ports:
+    expose:
       - 8983
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -21,7 +21,7 @@ services:
 #      - solr:/var/solr
   web:
     links:
-      - solr:$DDEV_HOSTNAME
+      - solr
 
 volumes:
   # solr is a persistent Docker volume for this project's solr data


### PR DESCRIPTION
1. You can't do the extension disable on web interface, so use typo3
2. Use expose instead of ports in docker-compose. No need to have ephemeral port on host.
3. The web:links was wrong, it should just be solr

