### PR TITLE
Update command to allow Redis to correctly open without error and use latest version of Redis.

### DIFF
--- a/docker-compose-services/redis/docker-compose.redis.yaml
+++ b/docker-compose-services/redis/docker-compose.redis.yaml
@@ -5,7 +5,7 @@ version: "3.6"
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:4
+    image: redis:latest
     ports:
       - 6379
     labels:
@@ -14,7 +14,7 @@ services:
     volumes:
       - ".:/mnt/ddev_config"
       - "./redis:/usr/local/etc/redis"
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    command: ["redis-server", "--bind", "redis", "--port", "6379"]
   web:
     depends_on:
       - redis

--- a/docker-compose-services/redis/docker-compose.redis.yaml
+++ b/docker-compose-services/redis/docker-compose.redis.yaml
@@ -5,7 +5,7 @@ version: "3.6"
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: redis:latest
+    image: redis:6.2
     ports:
       - 6379
     labels:


### PR DESCRIPTION
Change command to allow Redis to correctly open without error and use latest Redis version. Note: Required to add `REDIS_HOST=redis` to Laravel projects .env file as default of localhost is not appropriate inside the container.