### PR TITLE
Add recipe for Solr 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ General information on how to do additional services and some additional example
 * [Portainer Service for DDEV](docker-compose-services/portainer)
 * [PostgreSQL](docker-compose-services/postgres/)
 * [Solr 5 Integration](docker-compose-services/solr-5)
+* [Solr 7 Integration](docker-compose-services/solr-7)
 * [RabbitMQ](docker-compose-services/rabbitmq)
 * [redis](docker-compose-services/redis)
 * [redis-commander](docker-compose-services/redis-commander)

--- a/docker-compose-services/solr-7/README.md
+++ b/docker-compose-services/solr-7/README.md
@@ -33,3 +33,5 @@ services.solr:
 ```
 
 You'll also need to use the updated `solr-configupdate.sh` script, because the Solr 7 image uses the directory `/opt/solr/server/solr/mycores/${CORENAME}/conf`, which is different from some other versions.
+
+**Contributed by [@becw](https://github.com/becw)**

--- a/docker-compose-services/solr-7/README.md
+++ b/docker-compose-services/solr-7/README.md
@@ -1,0 +1,35 @@
+# Solr 7 for DDEV
+
+The documented ApacheSolr integration with DDEV assumes version 8 of Solr, but the Solr docker images have different configuration locations between versions of Solr. This means that the docker-compose file and `solr-configupdate.sh` script need to be tweaked for use with Solr 7.
+
+## General documentation
+
+* [DDEV Integration documentation](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr)
+* [Docker Solr documentation](https://hub.docker.com/_/solr/)
+
+## Installation
+
+1. Copy the `docker-compose.solr.yaml` file and the `solr/` directory into your `.ddev/` directory
+2. Copy your desired solr core configuration into the `.ddev/solr/conf/` directory
+  * You may be able to download your hosting provider's default core configuration
+  * You can also use the [jump start configuration](https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start/solr7/config-set) from `search_api_solr` module
+3. Start (or restart) ddev
+
+**Note:** If you had a different version of solr running before, you'll need to delete the previous Solr docker volume so that the Solr 7 one can be created:
+
+1. Use `docker volume ls` to list the volumes
+2. Identify your Solr volume -- it will be named with the pattern `ddev-example_solr`
+3. Use `docker volume rm [volume name]` to remove the volume
+
+## Differences between default `docker-compose.solr.yaml`
+
+If you don't want to follow the installation steps above, you can make these changes manually:
+
+```
+services.solr:
+  image: solr:7
+  volumes:
+    - solr:/opt/solr
+```
+
+You'll also need to use the updated `solr-configupdate.sh` script, because the Solr 7 image uses the directory `/opt/solr/server/solr/mycores/${CORENAME}/conf`, which is different from some other versions.

--- a/docker-compose-services/solr-7/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-7/docker-compose.solr.yaml
@@ -1,0 +1,89 @@
+# DDev Apache Solr recipe file.
+#
+# To use this in your own project:
+# 1. Copy this file to your project's ".ddev" directory.
+# 2. Create the folder path ".ddev/solr/conf".
+# 3. Copy the Solr configuration files for the appropriate plugin/module to
+#    ".ddev/solr/conf". For example, using Drupal 8's Search API Solr module,
+#    you'll get the config files as a file config.zip from
+#    /admin/config/search/search-api/server/solr and unzip it into .ddev/solr/conf
+#    so that a file exists with the path ".ddev/solr/conf/solrconfig.xml".
+#
+# To access Solr after it is installed:
+# - The Solr admin interface will be accessible at:
+#   http://<projectname>.ddev.site:8983/solr/
+#   For example, if the project is named "myproject" the hostname will be:
+#   http://myproject.ddev.site:8983/solr/
+# - To access the Solr container from the web container use:
+#   http://solr:8983/solr/
+# - A Solr core is automatically created with the name "dev" unless you
+#   change that usage throughout. It can be
+#   accessed at the URL: http://solr:8983/solr/dev (inside web container)
+#   or at http://myproject.ddev.site:8983/solr/dev (on the host)
+
+version: '3.6'
+
+services:
+  solr:
+    # Name of container using standard ddev convention
+    container_name: ddev-${DDEV_SITENAME}-solr
+    # The solr docker image is at https://hub.docker.com/_/solr/
+    # and code at https://github.com/docker-solr/docker-solr
+    # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
+    # It's almost impossible to work with it if you don't read the docs there
+    image: solr:7
+    restart: "no"
+    # Solr is served from this port inside the container.
+    ports:
+      - 8983
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.site.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # HTTP_EXPOSE exposes http traffic from the container port 8983
+      # to the host port 8983 vid ddev-router reverse proxy.
+      - HTTP_EXPOSE=8983:8983
+      # HTTPS_EXPOSE exposes https traffic from the container port 8983
+      # to the host port 8984 vid ddev-router reverse proxy.
+      - HTTPS_EXPOSE=8984:8983
+    volumes:
+      # solr core *data* is stored on the 'solr' docker volume
+      # This mount is optional; without it your search index disappears
+      # each time the ddev project is stopped and started.
+      - solr:/opt/solr
+
+      # This mounts the conf in .ddev/solr into the container where
+      # the solr-precreate command in the entrypoint uses it as a one-time
+      # configuration to copy config into the newly-created core. It is not
+      # used if the core has previously been created.
+      - ./solr:/solr-conf
+
+      - ".:/mnt/ddev_config"
+
+      # solr-configupdate.sh copies fresh configuration files into the
+      # solr container on each
+      # startup, so if you change the config in .ddev/solr/conf
+      # it will be refreshed on `ddev start`. The file must be
+      # executable (`chmod +x .ddev/solr/solr-configupdate.sh`)
+      - "./solr/solr-configupdate.sh:/docker-entrypoint-initdb.d/solr-configupdate.sh"
+
+    entrypoint: [ "sh", "-c", "docker-entrypoint.sh solr-precreate dev /solr-conf" ]
+
+    external_links:
+      - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
+
+  # This links the Solr service to the web service defined in the main
+  # docker-compose.yml, allowing applications running inside the web container to
+  # access the Solr service at http://solr:8983
+  web:
+    links:
+      - solr:solr
+volumes:
+  # solr is a persistent Docker volume for solr data
+  # The persistent volume should have the same name as the service so it can be deleted
+  # when the project is deleted.
+  solr:

--- a/docker-compose-services/solr-7/solr/conf/README.md
+++ b/docker-compose-services/solr-7/solr/conf/README.md
@@ -1,0 +1,3 @@
+Copy your desired solr core configuration into this directory.
+
+You may be able to download your hosting provider's default core configuration, or else you can use the [jump start configuration](https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start/solr7/config-set) from `search_api_solr` module.

--- a/docker-compose-services/solr-7/solr/solr-configupdate.sh
+++ b/docker-compose-services/solr-7/solr/solr-configupdate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# Ensure "dev" core config is always up to date even after the
+# core has been created. This does not execute the first time,
+# when solr-precreate has not yet run.
+CORENAME=dev
+if [ -d /opt/solr/server/solr/mycores/${CORENAME}/conf ]; then
+    # Replace existing conf dir entirely to ensure deleted config files are removed.
+    rm -r /opt/solr/server/solr/mycores/${CORENAME}/conf
+    cp -r /solr-conf/conf /opt/solr/server/solr/mycores/${CORENAME}/conf
+fi


### PR DESCRIPTION
I recently tried to use Solr 7 following the [setup instructions in the ddev documentation](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr). I found that the default docker-compose and core update script didn't work with the Solr 7 docker image, because some of the paths were different.

It's important to be able to match the Solr version on local development environments to what's available on hosting platforms, and at this time Acquia offers Solr 7.

### Testing instructions

1. Copy the `docker-compose.solr.yaml` file and the `solr/` directory into your `.ddev/` directory
2. Copy your desired solr core configuration into the `.ddev/solr/conf/` directory
  * You may be able to download your hosting provider's default core configuration
  * You can also use the [jump start configuration](https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start/solr7/config-set) from `search_api_solr` module
3. Start (or restart) ddev
4. Visit the Solr web UI for your ddev setup, like `http://EXAMPLE.ddev.site:8983`:
  * You should not see any errors at the top of the page
  * In the center of the page, it should show the Solr version as 7 (currently 7.7.3)
  * In the left sidebar, the "Core Selector" dropdown should contain the core `dev`

![image](https://user-images.githubusercontent.com/207974/115250558-4dedf380-a0ef-11eb-8e11-14d0c7c5d4d6.png)
