### PR TITLE
Corrected extra && typo in the config.sshd.yaml sshd recipe

### DIFF
--- a/recipes/sshd/config.sshd.yaml
+++ b/recipes/sshd/config.sshd.yaml
@@ -1,4 +1,4 @@
 hooks:
   post-start:
-  - exec: sudo chown -R $(id -un) /etc/ssh && && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222
+  - exec: sudo chown -R $(id -un) /etc/ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222
 webimage_extra_packages: [openssh-server]


### PR DESCRIPTION
Hook now executes successfully.

Previously Failed:

```
Executing post-start hook...
=== Running task: Exec command 'sudo chown -R $(id -un) /etc/ssh && && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222' in container/service 'web', output below
bash: -c: line 0: syntax error near unexpected token `&&'
bash: -c: line 0: `set -eu && ( sudo chown -R $(id -un) /etc/ssh && && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222)'
Task failed: Exec command 'sudo chown -R $(id -un) /etc/ssh && && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys && /usr/sbin/sshd -p 2222' in container/service 'web': exit status 1
```

<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
Corrected extra && typo in config.sshd.yaml

## How this PR Solves The Problem:
Removed the extra &&

## Manual Testing Instructions:
Just follow the existing [README.md instructions](https://github.com/drud/ddev-contrib/tree/master/recipes/sshd) of copying *.sshd.yaml files to the .ddev directory and .ssh files to home additions directory to see it fail with the old config.sshd.yaml file and them replace with the new file to see it succeed with the new config.sshd.yaml file.

## Related Issue Link(s):

