### PR TITLE
Fix missing "name" field in drupal-behat-selenium account_registration.feature

### DIFF
--- a/docker-compose-services/drupal8-behat-selenium/account_registration.feature
+++ b/docker-compose-services/drupal8-behat-selenium/account_registration.feature
@@ -8,5 +8,6 @@ I need to be able to complete the registration form
 Scenario: Complete the registration form
     Given I am on "/user/register"
     And I enter "t@gmail.com" for "edit-mail"
+    And I enter "tom" for "edit-name"
     And I check the box "edit-contact--2"
     And I press the "edit-submit" button


### PR DESCRIPTION
the name was left out.

<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## Name field not filled out

## Added Gherkin line to add the name

## run behat


