### PR TITLE
Fix location for general_log file

### DIFF
--- a/custom-commands/general-log/general_log
+++ b/custom-commands/general-log/general_log
@@ -59,4 +59,4 @@ function shutdown() {
 trap shutdown INT
 
 enable
-tail -f /var/lib/mysql/general_log.log 2> /dev/null
+tail -f /var/lib/mysql/general_log.log 

--- a/custom-commands/general-log/general_log
+++ b/custom-commands/general-log/general_log
@@ -42,6 +42,7 @@ function spinner() {
 }
 function enable() {
     printf "Enabling general_log "
+    mysql -uroot -proot <<< "SET GLOBAL general_log_file='general_log.log'"
     mysql -uroot -proot <<< "SET GLOBAL general_log=1" &
     spinner $!
     printf "%b✓%b \n" "${successC}" "${endC}"
@@ -58,4 +59,4 @@ function shutdown() {
 trap shutdown INT
 
 enable
-tail -f /var/lib/mysql/www.log 2> /dev/null
+tail -f /var/lib/mysql/general_log.log 2> /dev/null


### PR DESCRIPTION

## The New Solution/Problem/Issue/Bug:

The default `general_log_file` settings takes the DB container hostname into account.

## How this PR Solves The Problem:

This change just sets that setting to a known location that we can use later.

## Manual Testing Instructions:

Run `ddev general_log` on different projects (with and without project names beginning with `www.`). You should not see an error.

## Related Issue Link(s):

Fixes #133
