### PR TITLE
Fix array syntax in drupalci-chromedriver services example, fixes #132

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -6,17 +6,17 @@
 version: '3.6'
 services:
   chromedriver:
-      links:
-          web:web
     image:  drupalci/webdriver-chromedriver:production
     container_name: ddev-${DDEV_SITENAME}-chromedriver
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
+    external_links:
+      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
 
   web:
     links:
-      - chromedriver:$DDEV_HOSTNAME
+      - chromedriver
     environment:
       # *** One of these must be uncommented ***
       # In order for the system to work, one of these must be uncommented so


### PR DESCRIPTION
As pointed out in https://github.com/drud/ddev-contrib/issues/132, the drupalci-chromedriver example was completely broken, at least for recent versions of docker-compose.

I think this got broken in @damienmckenna 's https://github.com/drud/ddev-contrib/pull/118 , which had the wrong `links:` syntax, etc. 

@damienmckenna @eojthebrave @heddn @mglaman since your'e the de-facto maintainers of this, I'd appreciate if you could manually test and approve this. Right now it's completely unusable. 