### PR TITLE
Adding kibana service recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ General information on how to do additional services and some additional example
 * [DrupalCI with Headless Chrome and Behat](docker-compose-services/drupalci-chromedriver). This example uses Drupal's DrupalCI approach, supports Behat, DrupalCI, etc.
 * [Elasticsearch](docker-compose-services/elasticsearch)
 * [Elastichq](docker-compose-services/elastichq)
-* [Kibana](docker-compose-services/kibana)
 * [Headless Chrome for Behat Testing](docker-compose-services/headless-chrome)
+* [Kibana](docker-compose-services/kibana)
 * [MongoDB](docker-compose-services/mongodb/)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [PHP 8.1](docker-compose-services/php8_1) While it's in prerelease

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ General information on how to do additional services and some additional example
 * [DrupalCI with Headless Chrome and Behat](docker-compose-services/drupalci-chromedriver). This example uses Drupal's DrupalCI approach, supports Behat, DrupalCI, etc.
 * [Elasticsearch](docker-compose-services/elasticsearch)
 * [Elastichq](docker-compose-services/elastichq)
+* [Kibana](docker-compose-services/kibana)
 * [Headless Chrome for Behat Testing](docker-compose-services/headless-chrome)
 * [MongoDB](docker-compose-services/mongodb/)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)

--- a/docker-compose-services/elastichq/README.md
+++ b/docker-compose-services/elastichq/README.md
@@ -4,15 +4,17 @@ This recipe adds an ElasticHQ container to a project.
 
 This will allow you to have a graphical interface for browsing data in your Elasticsearch server.
 
+**Note to Apple M1 and other arm64 users: At last check the [elasticsearch-hq image](https://hub.docker.com/r/elastichq/elasticsearch-hq) was amd64-only, so your mileage may vary with this recipe.**
+
 ## Requirements
 
-Elastic HQ requires that there is a container within the project that has a working instance of Elasticsearch running for it to connect to. This is based on the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
+Elastic HQ requires a working instance of Elasticsearch running for it to connect to. This is based on the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
 
 ## Configuration
 
-If your Elasticsearch server is not available inside the elastichq container at `http://elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
+If your Elasticsearch server is not available inside the elastichq container at `http://ddev-<projectname>-elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.elastichq.yaml` and edit the following environment variable:
 
-* Change `HQ_DEFAULT_URL` to the url your Elasticsearch server is available at within the elastichq container.
+* Change `HQ_DEFAULT_URL` to the url where your Elasticsearch server is available from inside the elastichq container.
 
 ## Installation
 

--- a/docker-compose-services/elastichq/docker-compose.elastichq.yaml
+++ b/docker-compose-services/elastichq/docker-compose.elastichq.yaml
@@ -5,7 +5,7 @@ services:
     hostname: ${DDEV_SITENAME}-elastichq
     image: elastichq/elasticsearch-hq
     restart: always
-    ports:
+    expose:
       - "5000"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -14,7 +14,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=5000:5000
       - HTTPS_EXPOSE=5443:5000
-      - HQ_DEFAULT_URL=http://elasticsearch:9200
+      - HQ_DEFAULT_URL=http://ddev-${DDEV_PROJECT}-elasticsearch:9200
     volumes:
       - ".:/mnt/ddev_config"
   elasticsearch:

--- a/docker-compose-services/elasticsearch/README.md
+++ b/docker-compose-services/elasticsearch/README.md
@@ -8,11 +8,11 @@ Copy [docker-compose.elasticsearch.yaml](docker-compose.elasticsearch.yaml) to y
 
 ## Configuration
 
-From within the container, the elasticsearch container is reached at hostname: elasticsearch, port: 9200, so the server URL might be `http://elasticsearch:9200`. You can also use the non-SSL, and SSL urls to access it: `http://<DDEV_SITENAME>.ddev.site:9200`, and `https://<DDEV_SITENAME>.ddev.site:9201`
+From within the container, the elasticsearch container is reached at hostname: ddev-<projectname>-elasticsearch, port: 9200, so the server URL might be `http://ddev-<projectname>-elasticsearch:9200`. You can also use the non-SSL, and SSL urls to access it: `http://<projectname>.ddev.site:9200`, and `https://<projectname>.ddev.site:9201`
 
 ## Connection
 
-You can access the Elasticsearch server directly from the host for debugging purposes by visiting `http://<DDEV_SITENAME>.ddev.site:9200`. If you have SSL enabled, which is recommended, you can access Elasticsearch via `https://<DDEV_SITENAME>.ddev.site:9201`
+You can access the Elasticsearch server directly from the host for debugging purposes by visiting `http://<projectname>.ddev.site:9200`. If you have SSL enabled, which is recommended, you can access Elasticsearch via `https://<projectname>.ddev.site:9201`
 
 ## Memory Limit
 

--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -4,7 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
     image: elasticsearch:7.10.1
-    ports:
+    expose:
       - "9200"
       - "9300"
     environment:

--- a/docker-compose-services/kibana/README.md
+++ b/docker-compose-services/kibana/README.md
@@ -1,0 +1,25 @@
+# Kibana
+
+This recipe adds Kibana container to a project.
+
+This will allow you to visualize your Elasticsearch data and do anything from tracking query load to understanding the way requests flow through your apps.
+
+## Requirements
+
+Kibana requires a working instance of Elasticsearch running for it to connect to. This is based on the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
+
+## Configuration
+
+If your Elasticsearch server is not available inside the elastichq container at `http://elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.kibana.yaml` and edit the following environment variable:
+
+- Change `ELASTICSEARCH_HOSTS` to the url your Elasticsearch server is available at within the elastichq container.
+
+Current Kibana version is 7.10.1, to change the version you need to edit the `image` parameter in `docker-compose.kibana.yaml`
+
+## Installation
+
+- Copy `docker-compose.kibana.yaml` to the `.ddev` folder of your project.
+- Start (or restart) DDEV to have the service initialized: `ddev start`
+- Access Kibana at `http://<DDEV_STENAME>.ddev.site:5601`.
+
+**Contributed by [@alechko](https://github.com/alechko)**

--- a/docker-compose-services/kibana/README.md
+++ b/docker-compose-services/kibana/README.md
@@ -4,15 +4,15 @@ This recipe adds Kibana container to a project.
 
 This will allow you to visualize your Elasticsearch data and do anything from tracking query load to understanding the way requests flow through your apps.
 
+**Note to Apple M1 and other arm64 users: At last check the [kibana 7.10.1 image](https://www.docker.elastic.co/r/kibana/kibana:7.10.1) referenced here was amd64-only, so your mileage may vary with this recipe. You may want to use one of the multiplatform images like kibana/kibana:7.13.3 at [the elastic.co docker repository](https://www.docker.elastic.co/r/kibana)**
+
 ## Requirements
 
-Kibana requires a working instance of Elasticsearch running for it to connect to. This is based on the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
+Kibana requires a working instance of Elasticsearch running for it to connect to. This requires the [docker-compose recipe for elasticsearch in ddev-contrib](../elasticsearch).
 
 ## Configuration
 
-If your Elasticsearch server is not available inside the elastichq container at `http://elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.kibana.yaml` and edit the following environment variable:
-
-- Change `ELASTICSEARCH_HOSTS` to the url your Elasticsearch server is available at within the elastichq container.
+If your Elasticsearch server is not available inside the kibana container at `http://ddev-<projectname>-elasticsearch:9200` (as it is when using the [ddev-contrib recipe](../elasticsearch), then you need to edit `docker-compose.kibana.yaml` and edit the following and edit the`ELASTICSEARCH_HOSTS` environment variable to the url your Elasticsearch server is available at within the kibana container.
 
 Current Kibana version is 7.10.1, to change the version you need to edit the `image` parameter in `docker-compose.kibana.yaml`
 
@@ -20,6 +20,6 @@ Current Kibana version is 7.10.1, to change the version you need to edit the `im
 
 - Copy `docker-compose.kibana.yaml` to the `.ddev` folder of your project.
 - Start (or restart) DDEV to have the service initialized: `ddev start`
-- Access Kibana at `http://<DDEV_STENAME>.ddev.site:5601`.
+- Access Kibana at `https://<DDEV_STENAME>.ddev.site:5602`.
 
 **Contributed by [@alechko](https://github.com/alechko)**

--- a/docker-compose-services/kibana/docker-compose.kibana.yaml
+++ b/docker-compose-services/kibana/docker-compose.kibana.yaml
@@ -1,0 +1,22 @@
+version: '3.6'
+services:
+  kibana:
+    container_name: ddev-${DDEV_SITENAME}-kibana
+    hostname: ${DDEV_SITENAME}-kibana
+    image: docker.elastic.co/kibana/kibana:7.10.1
+    restart: always
+    ports:
+      - '5601'
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=5601:5601
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - SERVER_NAME=kibana
+    volumes:
+      - '.:/mnt/ddev_config'
+  elasticsearch:
+    links:
+      - kibana:kibana

--- a/docker-compose-services/kibana/docker-compose.kibana.yaml
+++ b/docker-compose-services/kibana/docker-compose.kibana.yaml
@@ -1,11 +1,11 @@
 version: '3.6'
 services:
   kibana:
-    container_name: ddev-${DDEV_SITENAME}-kibana
-    hostname: ${DDEV_SITENAME}-kibana
+    container_name: ddev-${DDEV_PROJECT}-kibana
+    hostname: ${DDEV_PROJECT}-kibana
     image: docker.elastic.co/kibana/kibana:7.10.1
-    restart: always
-    ports:
+    restart: "no"
+    expose:
       - '5601'
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -13,10 +13,10 @@ services:
     environment:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=5601:5601
-      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
-      - SERVER_NAME=kibana
+      - HTTPS_EXPOSE=5602:5601
+      - ELASTICSEARCH_HOSTS=http://ddev-${DDEV_PROJECT}-elasticsearch:9200
+      - SERVER_NAME=ddev-${DDEV_PROJECT}-elasticsearch
     volumes:
       - '.:/mnt/ddev_config'
-  elasticsearch:
-    links:
-      - kibana:kibana
+    depends_on:
+      - elasticsearch


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

Adding Kibana service to monitor/control Elasticsearch.

## Manual Testing Instructions:

Follow the Installation section in `docker-compose-services/kibana/README.md`


