### PR TITLE
Remove spurious ports: [] line from varnish config as it breaks under docker desktop 3.5+, fixes #144

### DIFF
--- a/docker-compose-services/varnish/docker-compose.varnish.yml
+++ b/docker-compose-services/varnish/docker-compose.varnish.yml
@@ -28,7 +28,6 @@ services:
       # your default.vcl should be.
       - "./varnish:/etc/varnish"
       - ".:/mnt/ddev_config"
-    ports: []
     links:
       - web:web
   # This is the second half of the trick that puts varnish "in front of" the web


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

#144 - an old bogus line now breaks docker-compose v2+

## How this PR Solves The Problem:

Remove the bogus line.

