### PR TITLE
Update README.md

### DIFF
--- a/docker-compose-services/solr-4/README.md
+++ b/docker-compose-services/solr-4/README.md
@@ -7,7 +7,7 @@ The Solr version used in this recipe is 4.10.4 which is not supported officially
 To enable Solr in your project follow these steps:
 
 1. Create a directory named _solr_ in your project's `.ddev` directory.
-1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev/solr`.
+1. Copy [docker-compose.solr.yml](docker-compose.solr.yml) into `.ddev`.
 1. Copy the [core.properties](core.properties) into `.ddev/solr` and edit it according to your needs.
 1. Create a new directory `.ddev/solr/data`.
 1. Copy the configuration suitable for Solr 4.x (including `schema.xml` and `solrconfig.xml`) into a new directory named `.ddev/solr/conf`.


### PR DESCRIPTION
docker-compose.solr.yml needs to go into `.ddev` not `.ddev/solr`.

<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:

I couldn't use the recipe for solr4 until I'd realised the file was in the wrong place.

## How this PR Solves The Problem:

It updates  the instructions with the correct place to copy the file.