### PR TITLE
fix drush command in solr-cloud README

### DIFF
--- a/docker-compose-services/solr-cloud/README.md
+++ b/docker-compose-services/solr-cloud/README.md
@@ -13,7 +13,7 @@ For Drupal and Search API you just need to switch the configured Solr Connector 
 Starting from Search API Solr module version 4.2.1 you don't need to deal with configsets manually any more. Just enable the `search_api_solr_admin` sub-module and configure the Search API Server to use the Solr Cloud Connector with Basic Auth. The username "solr" and the password "SolrRocks" are pre-configured in `.ddev/solr-cloud/security.json`. Now you
 create or update your collection any time by clicking the "Upload Configset" button on the Search API server details page, or automate things using
 ```
-ddev drush search_api_solr:upload-configset SERVER_ID
+ddev drush search-api-solr:upload-configset SERVER_ID
 ```
 
 **Contributed by [@mkalkbrenner](https://github.com/mkalkbrenner)**


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
the drush command `search_api_solr` is incorrect
## How this PR Solves The Problem:
It corrects it to `search-api-solr`
## Manual Testing Instructions:
follow the instructions in the readme for setting up solr cloud, use the drush command to push config.
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

## Related Issue Link(s):

