### PR TITLE
Use official image for postgres

### DIFF
--- a/docker-compose-services/postgres/docker-compose.postgres.yaml
+++ b/docker-compose-services/postgres/docker-compose.postgres.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
   postgres:
     container_name: ddev-${DDEV_SITENAME}-postgres
-    image: mdillon/postgis:11
+    image: postgres:13.4
     ports:
       - 32784:5432
     environment:


### PR DESCRIPTION
The existing postgres recipe uses an unmaintained postgres image (`mdillon/postgis:11`), which also does not have arm64 images. 

This switches it to use the current official postgres image, `postgres:13.4`

@penyaskito @pcambra @rvolk @d3pendent @dacostafilipe Please make sure this is OK with you. I don't know why it was using an off-brand image to begin with.