### PR TITLE
Fix: Failed to run pgsql_export, fixes #153

### DIFF
--- a/docker-compose-services/postgres/commands/postgres/pgsql_export
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_export
@@ -4,4 +4,4 @@
 ## Usage: pgsql_export
 ## Example: ddev pgsql_export
 
-mkdir -p /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/import-db/postgresql.db.sql"
+mkdir -p /mnt/ddev_config/import-db && chmod 777 /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/import-db/postgresql.db.sql"


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->
- The `pgsql_export` command is currently broken. Attemps to use it result in the following error:

```bash
$ ddev pgsql_export
bash: /mnt/ddev_config/import-db/postgresql.db.sql: Permission denied
Failed to run pgsql_export : exit status 1
```

- See #153

## The New Solution/Problem/Issue/Bug:
This fixes a permission issue when using `ddev pgsql_export` by changing the permission before running the problematic command. 

- Note: No documentation update is required.

## How this PR Solves The Problem:
Change permission on `/mnt/ddev_config/import-db`

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->
- Follow instructions to install Postgres service in a project
- Confirm project has working database connection
- Run the following command:

```bash
ddev pgsql_export
```

## Related Issue Link(s):
fixes #153
