### PR TITLE
fix minor postgres-restore comment

### DIFF
--- a/docker-compose-services/postgres/commands/postgres/pgsql_restore
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_restore
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Restore the postgresql database from a postgre custom format dump located in .ddev/import-db/postgresql.db.backup
+## Description: Restore the postgresql database from a postgre custom format dump located in .ddev/import-db/postgresql.db.dump
 ## Usage: pgsql_restore
 ## Example: ddev pgsql_restore
 


### PR DESCRIPTION


<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->
The current comment does not reflect the current command being used.

- The comment refers to a "... custom format dump located in .ddev/import-db/postgresql.db.backup".
- The commend references ".../import-db/postgresql.db.dump"

## The New Solution/Problem/Issue/Bug:
Assuming the command line is the "correct" version (since thats whats doing the work), the comment should be updated to reflect this.


## How this PR Solves The Problem:
- Comment updated

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

## Related Issue Link(s):

