### PR TITLE
Rename directory for pgsql import/export from import-db to psql-db

### DIFF
--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -32,8 +32,8 @@ When using multiple project with PostgreSQL support, remember to update your `do
 
 Two new `ddev` commands are provided:
 
-* `ddev pgsql_export` : Use `pg_dump` to export `db` to `.ddev/import-db/postgresql.db.sql`
-* `ddev pgsql_import` : Use `pgsql` to import `.ddev/import-db/postgresql.db.sql` into `db` - Note that this must be executed with an empty database.
+* `ddev pgsql_export` : Use `pg_dump` to export `db` to `.ddev/pgsql-db/postgresql.db.sql`
+* `ddev pgsql_import` : Use `pgsql` to import `.ddev/pgsql-db/postgresql.db.sql` into `db` - Note that this must be executed with an empty database.
 
 Example `config.yaml` hooks configuration to automatically import/export the `db` table:
 
@@ -50,7 +50,7 @@ hooks:
 ```
 
 There are also another non-plain-text formats that `pg_dump` can generate, and you might need to work with them. If that's the case, there is also
-a `ddev pg_restore` command that will restore `.ddev/import-db/postgresql.db.dump` into `db`.
+a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump` into `db`.
 
 ## PostGIS
 

--- a/docker-compose-services/postgres/commands/postgres/pgsql_export
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_export
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Dump the postgresql database to .ddev/import-db/postgresql.db.sql
+## Description: Dump the postgresql database to .ddev/pgsql-db/postgresql.db.sql
 ## Usage: pgsql_export
 ## Example: ddev pgsql_export
 

--- a/docker-compose-services/postgres/commands/postgres/pgsql_import
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_import
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Load to an empty postgresql database from .ddev/import-db/postgresql.db.sql
+## Description: Load to an empty postgresql database from .ddev/pgsql-db/postgresql.db.sql
 ## Usage: pgsql_import
 ## Example: ddev pgsql_import
 
@@ -8,4 +8,4 @@
 su postgres -c "psql -U db -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO db; GRANT ALL ON SCHEMA public TO public;'"
 
 # Import via user postgres to avoid credentials prompt
-su postgres -c "psql -U db db < /mnt/ddev_config/import-db/postgresql.db.sql"
+su postgres -c "psql -U db db < /mnt/ddev_config/pgsql-db/postgresql.db.sql"

--- a/docker-compose-services/postgres/commands/postgres/pgsql_restore
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_restore
@@ -8,4 +8,4 @@
 su postgres -c "psql -U db -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO db; GRANT ALL ON SCHEMA public TO public;'"
 
 # Import via user postgres to avoid credentials prompt
-su postgres -c "pg_restore --no-owner -U db -d db /mnt/ddev_config/import-db/postgresql.db.dump"
+su postgres -c "pg_restore --no-owner -U db -d db /mnt/ddev_config/pgsql-db/postgresql.db.dump"


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
This is perhaps a matter of personal preference, but I think renaming `import-db` to a more specific `pgsql-db` makes it's purpose more clear. 


## How this PR Solves The Problem:

- The folder is used by the pgsql command
- The folder is specific for postgres
- The folder is not just for importing, but general "db" matters

The documents refer to:
- postgresql
- postgres
- postgre (although this has one reference and might be a typo)
- pgsql
- psql

`pgsql-db` was chosen as the new folder name to link the commands (pgsql_export, pgsql_import etc.) with it's purpose (database).

I'm happy for the name to be changed. This felt like the simpliest and shortest at the time.


## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

## Related Issue Link(s):

