### PR TITLE
Create additional databases for Postgres, fixes #159

### DIFF
--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -54,7 +54,7 @@ a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump
 
 ## Multiple databases
 
-* By default, DDEV adds a single database called `db`. But it's possible to create additional databases when you first initialize this service.
+* By default, this recipe adds a single database called `db`. But it's possible to create additional databases when you first initialize this service.
 
 * The offical way to add multiple databases is outlined on the [docker image](https://hub.docker.com/_/postgres) under the "Initialization scripts"
 
@@ -81,22 +81,7 @@ EG. Lets create a second database called `testing`.
 
 * Note: All *.sql,*.sql.gz, & *.sh files in `./.ddev/pgsql-db` will be executed so you can create multiple database or even seed data.
 
-* Note: These files "are only run if you start the container with a data directory that is empty". IE. The first time you start the project. For exisiting projects, you must remove the volume first. Remember to backup the database first (Eg. `ddev pgsql_export`).
-
-### Removing a postgres volume
-
-  ```bash
-  # Display all docker volumes.
-  docker volume ls
-
-  # Stop DDEV.
-  ddev stop
-
-  # Remove 'example' project postgres volume.
-  docker volume rm ddev-example_postgres
-  ```
-
-* If you recieve a `Error response from daemon: ... volume is in use`, you need to stop DDEV first.
+* Note: These files "are only run if you start the container with a data directory that is empty". IE. The first time you start the project. For exisiting projects, add a hook to [import a sql dump if the database is empty](https://github.com/drud/ddev-contrib/tree/master/hook-examples/import-db-if-empty), or run `ddev delete` to re-initialize the project. Remember to backup the database first (Eg. `ddev pgsql_export`).
 
 ## PostGIS
 

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -60,12 +60,11 @@ a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump
 
 EG. Lets create a second database called `testing`.
 
-* Add an additional volume to `./.ddev/docker-composer.postgres.yaml`
+* Add `./pgsql-db:/docker-entrypoint-initdb.d` to the `volumes` section in to `./.ddev/docker-composer.postgres.yaml`
 
   ```yaml
       volumes:
-      ...
-      - "./pgsql-db:/docker-entrypoint-initdb.d"
+        - "./pgsql-db:/docker-entrypoint-initdb.d"
   ```
 
 * Create `./.ddev/pgsql-db` folder if it doesn't already exist

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -99,11 +99,6 @@ To implement this in DDEV:
 
 * If you recieve a `Error response from daemon: ... volume is in use`, you need to stop DDEV first.
 
-### `ddev pgsql_export` auto-import
-
-* The file created by `ddev pgsql_export` is a great example of some of the commands you can use.
-* If this file exists, and the database data directory is empty (ie. you deleted the volume), the file will automatically by imported and populate your database!
-
 ## PostGIS
 
 The `postgres` image support `postgis`, but you will need to create the extension before using it:

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -58,7 +58,7 @@ a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump
 
 * The offical way to add multiple databases is outlined on the [docker image](https://hub.docker.com/_/postgres) under the "Initialization scripts"
 
-To implement this in DDEV:
+EG. Lets create a second database called `testing`.
 
 * Add an additional volume to `./.ddev/docker-composer.postgres.yaml`
 
@@ -74,13 +74,13 @@ To implement this in DDEV:
   mkdir ./.ddev/pgsql-db -p
   ```
 
-* Add your *.sql,*.sql.gz, or *.sh files to `./.ddev/pgsql-db`. EG. Create a file called `./.ddev/pgsql-db/create_testing_database.sql` and add the following:
+* Create a file called `./.ddev/pgsql-db/create_testing_database.sql` and add the following:
 
   ```sql
   CREATE DATABASE testing
   ```
 
-* In fact, you could put any valid SQL connect such as creating or seeding the database.
+* Note: All *.sql,*.sql.gz, & *.sh files in `./.ddev/pgsql-db` will be executed so you can create multiple database or even seed data.
 
 * Note: These files "are only run if you start the container with a data directory that is empty". IE. The first time you start the project. For exisiting projects, you must remove the volume first. Remember to backup the database first (Eg. `ddev pgsql_export`).
 

--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -52,6 +52,58 @@ hooks:
 There are also another non-plain-text formats that `pg_dump` can generate, and you might need to work with them. If that's the case, there is also
 a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump` into `db`.
 
+## Multiple databases
+
+* By default, DDEV adds a single database called `db`. But it's possible to create additional databases when you first initialize this service.
+
+* The offical way to add multiple databases is outlined on the [docker image](https://hub.docker.com/_/postgres) under the "Initialization scripts"
+
+To implement this in DDEV:
+
+* Add an additional volume to `./.ddev/docker-composer.postgres.yaml`
+
+  ```yaml
+      volumes:
+      ...
+      - "./pgsql-db:/docker-entrypoint-initdb.d"
+  ```
+
+* Create `./.ddev/pgsql-db` folder if it doesn't already exist
+
+  ```bash
+  mkdir ./.ddev/pgsql-db -p
+  ```
+
+* Add your *.sql,*.sql.gz, or *.sh files to `./.ddev/pgsql-db`. EG. Create a file called `./.ddev/pgsql-db/create_testing_database.sql` and add the following:
+
+  ```sql
+  CREATE DATABASE testing
+  ```
+
+* In fact, you could put any valid SQL connect such as creating or seeding the database.
+
+* Note: These files "are only run if you start the container with a data directory that is empty". IE. The first time you start the project. For exisiting projects, you must remove the volume first. Remember to backup the database first (Eg. `ddev pgsql_export`).
+
+### Removing a postgres volume
+
+  ```bash
+  # Display all docker volumes.
+  docker volume ls
+
+  # Stop DDEV.
+  ddev stop
+
+  # Remove 'example' project postgres volume.
+  docker volume rm ddev-example_postgres
+  ```
+
+* If you recieve a `Error response from daemon: ... volume is in use`, you need to stop DDEV first.
+
+### `ddev pgsql_export` auto-import
+
+* The file created by `ddev pgsql_export` is a great example of some of the commands you can use.
+* If this file exists, and the database data directory is empty (ie. you deleted the volume), the file will automatically by imported and populate your database!
+
 ## PostGIS
 
 The `postgres` image support `postgis`, but you will need to create the extension before using it:

--- a/docker-compose-services/postgres/docker-compose.postgres.yaml
+++ b/docker-compose-services/postgres/docker-compose.postgres.yaml
@@ -19,6 +19,7 @@ services:
         source: "."
         target: "/mnt/ddev_config"
       - ddev-global-cache:/mnt/ddev-global-cache
+      - "./pgsql-db:/docker-entrypoint-initdb.d"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
I have a project that uses a postgres db. I usually use an im_memory sqlite database for testing because its fast. 

Recently, I was debugging an issue which came down to a difference between postgres & sqlite databases so I needed to change my tests to use postgres.  This started me down the path of "how do I add an additional db to a DDEV postgres container".


## How this PR Solves The Problem:
The offical way to add multiple databases is outlined on the docker image site under the "Initialization scripts".

We simply add a volume and it works. I've used the same folder as the `pgsql_export` command to reduce clutter.

This also adds several possibilies:
- Run any abritary query code.
- Remove the need to use hooks to import on first run
- If `pgsql_export` has previously run, it will auto-import it (cool)

This will *only* run if the volume is empty so it's non-destructive. 


## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

Setup database:
- Setup a postgres database
- Add content
- Export with `ddev pgsql_export`.  Temporarily move this file somewhere else.

 Reset database:
- Power down ddev 
- Remove postgres volume for project
- Start DDEV and confirm database is empty

Making it work:
- Power down ddev 
- Move the previously created SQL file back to `./.ddev/psgql-db`
- Start DDEV & confirm database has restored.



