### PR TITLE
update pgsql_export command to use stated directory

### DIFF
--- a/docker-compose-services/postgres/commands/postgres/pgsql_export
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_export
@@ -4,4 +4,4 @@
 ## Usage: pgsql_export
 ## Example: ddev pgsql_export
 
-mkdir -p /mnt/ddev_config/import-db && chmod 777 /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/import-db/postgresql.db.sql"
+mkdir -p /mnt/ddev_config/import-db && chmod 777 /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/pgsql-db/postgresql.db.sql"


### PR DESCRIPTION
The description and documentation mentions the PG export will go into location like '.ddev/pgsql-db/postgresql.db.sql'. 
This update ensures that to be true.

