### PR TITLE
Added solr cloud with a single node in standalone mode

### DIFF
--- a/docker-compose-services/solr-cloud/README.md
+++ b/docker-compose-services/solr-cloud/README.md
@@ -1,19 +1,31 @@
 # Apache Solr Cloud Integration for DDEV-Local
 
-Although ddev has [documented generic Solr support](https://ddev.readthedocs.io/en/stable/users/extend/additional-services/#apache-solr) it only supports the single core mode and requires you to deal with configsets.
+Running Solr in single core mode is not the recommended way anymore. The "Solr Cloud" mode is the preferred way and
+offers many additional features like Streaming Expressions and APIs that make management easier.
 
-Running Solr in single core mode is not the recommended way anymore. The "Solr Cloud" mode is the preferred way and offers many additional features like Streaming Expressions and APIs that make management easier. 
+In a production environment it is recommended to have at least three Solr nodes that build that "cloud". In a
+development environment you can choose to only run a single node in standalone mode to require less memory or CPU. DDEV
+offers both options. You choose to run three nodes or a single node in standalone mode by copying either
+`docker-compose.solr-cloud.yaml` of `docker-compose.solr-cloud-standalone.yaml` to your project's `.ddev` folder.
 
-To use Solr Cloud copy the `docker-compose.solr-cloud.yaml` and the `solr-cloud` directory (including `security.json`) to your project's `.ddev` folder.
+For both variations you also need to copy the `solr-cloud` directory (including `security.json`) to your project's
+`.ddev` folder.
 
 ## Drupal and Search API
 
 For Drupal and Search API you just need to switch the configured Solr Connector to a Solr Cloud Connector.
 
-Starting from Search API Solr module version 4.2.1 you don't need to deal with configsets manually any more. Just enable the `search_api_solr_admin` sub-module and configure the Search API Server to use the Solr Cloud Connector with Basic Auth. The username "solr" and the password "SolrRocks" are pre-configured in `.ddev/solr-cloud/security.json`. Now you
-create or update your collection any time by clicking the "Upload Configset" button on the Search API server details page, or automate things using
+Starting from Search API Solr module version 4.2.1 you don't need to deal with configsets manually anymore. Just enable
+the `search_api_solr_admin` sub-module and configure the Search API Server to use the Solr Cloud Connector with Basic
+Auth. The username "solr" and the password "SolrRocks" are pre-configured in `.ddev/solr-cloud/security.json`. Now you
+create or update your collection any time by clicking the "Upload Configset" button on the Search API server details
+page, or automate things using
 ```
 ddev drush search-api-solr:upload-configset SERVER_ID
 ```
+
+Note: If you choose to run Solr Cloud using a single node in standalone mode, you need to limit the number of "shards"
+      to "1" when uploading the configset. There's a corresponding option in the UI and a parameter for the drush
+      command.
 
 **Contributed by [@mkalkbrenner](https://github.com/mkalkbrenner)**

--- a/docker-compose-services/solr-cloud/docker-compose.solr-cloud-standalone.yaml
+++ b/docker-compose-services/solr-cloud/docker-compose.solr-cloud-standalone.yaml
@@ -1,0 +1,71 @@
+# DDev Solr Cloud recipe file.
+#
+# This is a variation of cocker-compose.solr-cloud.yaml that only creates one Solr node and runs a single zookeeper in
+# in standalone mode. This setup is not recommended for a production envrionment but requires less ressources in a
+# development environment.
+#
+# To access Solr after it is installed:
+# - The Solr admin interface will be accessible at:
+#   http://<projectname>.ddev.site:8983/solr/
+#   For example, if the project is named "myproject" the hostname will be:
+#   http://myproject.ddev.site:8983/solr/
+# - To access the Solr container from the web container use:
+#   http://myproject.ddev.site:8983/solr/
+#
+# To use this in your own project:
+# 1. Copy this file and the solr-cloud (including security.json) directory to your project's ".ddev" directory.
+# 2. For Drupal:
+#      - enable the search_api_solr_admin (this sub-module included in Search API Solr >= 4.2.1)
+#      - create a search server using the Solr Cloud Connector with Basic Auth using username "solr" and password
+#        "SolrRocks".
+#      - press the "Upload Configset" button.
+#      - set the number of shards to "1" and press "Upload"
+
+version: '3.6'
+services:
+  solr:
+    image: solr:8
+    container_name: ddev-${DDEV_SITENAME}-solr
+    restart: "no"
+    expose:
+      - 8983
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      SOLR_HOST: ddev-${DDEV_SITENAME}-solr
+      SOLR_PORT: 8983
+      # The pre-trained OpenNLP models require a much bigger buffer.
+      SOLR_OPTS: -Djute.maxbuffer=50000000
+      #SOLR_HEAP: 1g
+      ZK_HOST: ddev-${DDEV_SITENAME}-zoo:2181
+      VIRTUAL_HOST: $DDEV_HOSTNAME
+      HTTP_EXPOSE: 8983:8983
+      HTTPS_EXPOSE: 8993:8983
+    depends_on:
+      - zoo
+    volumes:
+      - .:/mnt/ddev_config
+      - solr:/var/solr
+    command: bash -c "docker-entrypoint.sh solr zk cp file:/mnt/ddev_config/solr-cloud/security.json zk:/security.json && exec solr-foreground"
+
+  zoo:
+    image: zookeeper:3.6
+    container_name: ddev-${DDEV_SITENAME}-zoo
+    hostname: ddev-${DDEV_SITENAME}-zoo
+    restart: always
+    expose:
+      - 2181
+      - 7000
+    environment:
+      # The pre-trained OpenNLP models require a much bigger buffer.
+      JVMFLAGS: -Djute.maxbuffer=50000000
+      ZOO_MY_ID: 1
+      ZOO_SERVERS: server.1=ddev-${DDEV_SITENAME}-zoo1:2888:3888;2181
+      ZOO_4LW_COMMANDS_WHITELIST: mntr, conf, ruok
+      ZOO_CFG_EXTRA: "metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.exportJvmInfo=true"
+    volumes:
+      - .:/mnt/ddev_config
+
+volumes:
+  solr:

--- a/docker-compose-services/solr-cloud/docker-compose.solr-cloud.yaml
+++ b/docker-compose-services/solr-cloud/docker-compose.solr-cloud.yaml
@@ -11,7 +11,7 @@
 # To use this in your own project:
 # 1. Copy this file and the solr-cloud (including security.json) directory to your project's ".ddev" directory.
 # 2. For Drupal:
-#      - activate the search_api_solr_admin (this sub-module included in Search API Solr >= 4.2.1)
+#      - enable the search_api_solr_admin (this sub-module included in Search API Solr >= 4.2.1)
 #      - create a search server using the Solr Cloud Connector with Basic Auth using username "solr" and password
 #        "SolrRocks".
 #      - press the "Upload Configset" button.
@@ -32,6 +32,7 @@ services:
       SOLR_PORT: 8983
       # The pre-trained OpenNLP models require a much bigger buffer.
       SOLR_OPTS: -Djute.maxbuffer=50000000
+      #SOLR_HEAP: 1g
       ZK_HOST: ddev-${DDEV_SITENAME}-zoo1:2181,ddev-${DDEV_SITENAME}-zoo2:2181,ddev-${DDEV_SITENAME}-zoo3:2181
       VIRTUAL_HOST: $DDEV_HOSTNAME
       HTTP_EXPOSE: 8983:8983
@@ -41,10 +42,9 @@ services:
       - zoo2
       - zoo3
     volumes:
-      - ./solr-cloud/security.json:/var/security.json
       - .:/mnt/ddev_config
       - solr1:/var/solr
-    command: bash -c "docker-entrypoint.sh solr zk cp file:/var/security.json zk:/security.json && exec solr-foreground"
+    command: bash -c "docker-entrypoint.sh solr zk cp file:/mnt/ddev_config/solr-cloud/security.json zk:/security.json && exec solr-foreground"
 
   solr2:
     image: solr:8
@@ -60,6 +60,7 @@ services:
       SOLR_PORT: 8984
       # The pre-trained OpenNLP models require a much bigger buffer.
       SOLR_OPTS: -Djute.maxbuffer=50000000
+      #SOLR_HEAP: 1g
       ZK_HOST: ddev-${DDEV_SITENAME}-zoo1:2181,ddev-${DDEV_SITENAME}-zoo2:2181,ddev-${DDEV_SITENAME}-zoo3:2181
       VIRTUAL_HOST: $DDEV_HOSTNAME
       HTTP_EXPOSE: 8984:8984
@@ -85,6 +86,7 @@ services:
       SOLR_PORT: 8985
       # The pre-trained OpenNLP models require a much bigger buffer.
       SOLR_OPTS: -Djute.maxbuffer=50000000
+      #SOLR_HEAP: 1g
       ZK_HOST: ddev-${DDEV_SITENAME}-zoo1:2181,ddev-${DDEV_SITENAME}-zoo2:2181,ddev-${DDEV_SITENAME}-zoo3:2181
       VIRTUAL_HOST: $DDEV_HOSTNAME
       HTTP_EXPOSE: 8985:8985


### PR DESCRIPTION
In a production environment it is recommended to have at least three Solr nodes that build that "cloud". In a development environment you can choose to only run a single node in standalone mode to require less memory or CPU.