### PR TITLE
Documents the redis host and port name, fixes #163.

### DIFF
--- a/docker-compose-services/redis/README.md
+++ b/docker-compose-services/redis/README.md
@@ -8,6 +8,9 @@ This recipe adds a Redis container to a project.
 * If you need *Redis 5* change the image version as `redis:5` in `.ddev/docker-compose.redis.yaml`.
 * Update the example redis configuration file to your needs: `.ddev/redis/redis.conf`.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
+* By default, your redis instance is available at the following:
+    * Host `ddev-${DDEV_SITENAME}-redis`
+    * Port `6379`
 
 Now you can use `ddev redis-cli` to access the redis cli in the redis container.
 

--- a/docker-compose-services/redis/README.md
+++ b/docker-compose-services/redis/README.md
@@ -8,7 +8,7 @@ This recipe adds a Redis container to a project.
 * If you need *Redis 5* change the image version as `redis:5` in `.ddev/docker-compose.redis.yaml`.
 * Update the example redis configuration file to your needs: `.ddev/redis/redis.conf`.
 * Start (or restart) DDEV to have the service initialized: `ddev start`
-* By default, your redis instance is available at the following:
+* Your redis instance is available **inside the containers** at `ddev-<projectname>-redis:6379`:
     * Host `ddev-${DDEV_SITENAME}-redis`
     * Port `6379`
 


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
For noobs like me I have to go digging round for the redis host and port when I add it to DDEV.

## How this PR Solves The Problem:
This adds that information to the readme so that its blindingly obvious.

