### PR TITLE
Use chromium-based image for headless-chrome, supporting arm64

### DIFF
--- a/docker-compose-services/headless-chrome/README.md
+++ b/docker-compose-services/headless-chrome/README.md
@@ -11,11 +11,11 @@ I moved from selenium + Chrome to Headless Chrome because it's faster than Selen
 An example of how to use this is provided in [behat blog post](https://gorannikolovski.com/blog/drupal-8-and-behat-tests):
 
 * `ddev composer require --dev behat/behat dmore/behat-chrome-extension drupal/drupal-extension bex/behat-screenshot` to install the needed tools if not already in your project.
-* Copy the example [behat.yml](behat.yml) provided here into the root of your project (it will be /var/www/html/behat.yml).
-* Edit "base_url" under `Drupal\MinkExtension`in the behat.yml
-* `ddev ssh -d /var/www/html` to get into the container and work in /var/www/html (which is the root of your project).
+* Copy the example [behat.yml](behat.yml) provided here into the root of your project (it will be /var/www/html/behat.yml inside the container).
+* Edit "base_url" under `Drupal\MinkExtension`in the behat.yml. Use the `http` URL for your project rather than `https` because the chrome container does not trust the mkcert certificate used in the web container.
+* `ddev ssh` to get into the container and work in `/var/www/html` (which is the root of your project).
 * `vendor/bin/behat --init`
 * Copy [first-test.feature](first-test.feature) into the features directory that has just been created in the root of your repository.
-* `vendor/bin/behat` (inside the container) will test first-feature (which works on a default Drupal 8 profile install)
+* `behat` (inside the container) or `ddev exec behat` on the host will test first-feature (which works on a default Drupal 9 profile install)
 
 **Contributed by [isholgueras](https://github.com/isholgueras)**

--- a/docker-compose-services/headless-chrome/behat.yml
+++ b/docker-compose-services/headless-chrome/behat.yml
@@ -9,7 +9,7 @@ default:
     extensions:
         DMore\ChromeExtension\Behat\ServiceContainer\ChromeExtension: ~
         Drupal\MinkExtension:
-            base_url: https://<PROJECTNAME>>.ddev.site
+            base_url: https://<PROJECTNAME>.ddev.site
             ajax_timeout: 30
             # goutte: ~
             browser_name: chrome

--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -2,8 +2,7 @@
 version: '3.6'
 services:
     chrome:
-        # swap this for an isholgueras image when https://github.com/isholgueras/chrome-headless/pull/2 goes in
-        image:  randyfay/chrome-headless:chromium-isholgueras
+        image:  isholgueras/chrome-headless:latest
         restart: unless-stopped
         container_name: ddev-${DDEV_SITENAME}-chrome
         labels:

--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -2,7 +2,8 @@
 version: '3.6'
 services:
     chrome:
-        image:  isholgueras/chrome-headless:latest
+        # swap this for an isholgueras image when https://github.com/isholgueras/chrome-headless/pull/2 goes in
+        image:  randyfay/chrome-headless:chromium-isholgueras
         restart: unless-stopped
         container_name: ddev-${DDEV_SITENAME}-chrome
         labels:
@@ -19,7 +20,3 @@ services:
         # Exposing this port allows you to visit 127.0.0.1:9222 to see what Headless Chrome doing without
         # any additional configuration; However, you can only have one project using this port at a time.
             - '9222:9222'
-networks:
-    default:
-        external:
-            name: ddev_default


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

This makes minor change to have headless-chrome use a chromium-based image that is available in both arm64 and amd64. 

See https://github.com/isholgueras/chrome-headless/pull/2

/cc @isholgueras 


## Manual Testing Instructions:

Use the regular manual testing instructions for this recipe.

## Related Issue Link(s):

