### PR TITLE
✨  add Cypress E2E testing service

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 
 General information on how to do additional services and some additional examples are [in the docs](https://ddev.readthedocs.io/en/latest/users/extend/additional-services/).
 
+* [Integrate Cypress (E2E testing)](docker-compose-services/cypress)
 * [Behat, Selenium, Drupal 8/9](docker-compose-services/drupal8-behat-selenium)
 * [DrupalCI with Headless Chrome and Behat](docker-compose-services/drupalci-chromedriver). This example uses Drupal's DrupalCI approach, supports Behat, DrupalCI, etc.
 * [Elasticsearch](docker-compose-services/elasticsearch)
@@ -46,7 +47,6 @@ General information on how to do additional services and some additional example
 * [RabbitMQ](docker-compose-services/rabbitmq)
 * [redis](docker-compose-services/redis)
 * [redis-commander](docker-compose-services/redis-commander)
-* [Solr Integration (Drupal-focused)](docker-compose-services/solr)
 * [Solr 4 Integration (Drupal-focused)](docker-compose-services/solr-4)
 * [Solr 5 Integration (Drupal-focused)](docker-compose-services/solr-5)
 * [Solr 7 Integration (Drupal-focused)](docker-compose-services/solr-7)

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -1,0 +1,94 @@
+# Intergrate Cypress (E2E testing) <!-- omit in toc -->
+
+- [Steps](#steps)
+  - [A note about the Cypress image](#a-note-about-the-cypress-image)
+- [Commands](#commands)
+  - [`cypress:open`](#cypressopen)
+  - [`cypress:run`](#cypressrun)
+- [Notes](#notes)
+- [Troubleshooting](#troubleshooting)
+  - ["Could not find a Cypress configuration file, exiting"](#could-not-find-a-cypress-configuration-file-exiting)
+  - ["Unable to open X display."](#unable-to-open-x-display)
+
+[Cypress](https://www.cypress.io/) is a "complete end-to-end testing experience". It allows you to write Javascript test files that automate real browsers.  For more details, see the [Cypress Overview](https://docs.cypress.io/guides/overview/why-cypress) page.
+
+This recipe integrates a Cypress docker image with your DDEV project.
+
+## Steps
+
+- Copy the `docker-compose.cypress.yaml` file into your project's `./.ddev' directory.
+- Copy the `commands` directory into your project's `./.ddev/commands` directory
+- Restart DDEV to begin using the this service.
+
+    ```shell
+    ddev restart
+    ```
+
+### A note about the Cypress image
+
+This recipe uses the latest `cypress/include` image (`cypress/include:8.6.0`) which includes the following browsers:
+
+- Chrome 91
+- Firefox 89
+- Electron 91
+
+It is considered best practice to use a [specific image tag](https://github.com/cypress-io/cypress-docker-images#best-practice).
+
+- If you require a specific browser, update `image` in your `./.ddev/docker-compose.cypress.yaml`.
+- Available images and versions can be found on the [cypress-docker-images](https://github.com/cypress-io/cypress-docker-images) page.
+
+## Commands
+
+Cypress can run into 2 different modes: interactive and runner.
+This recipe includes 2 alias commands to help you use Cypress.
+
+### `cypress:open`
+
+To open cypress in "interactive" mode, run the following command:
+
+```shell
+ddev cypress:open
+```
+
+This command also accepts arguments. Refer to the ["#cyress open" documentation](https://docs.cypress.io/guides/guides/command-line#cypress-open) for further details.
+
+Example: To open Cypress in interactive mode, and specify a config file
+
+```shell
+ddev cypress:open --config cypress.json
+```
+
+### `cypress:run`
+
+To run Cypress in "runner" mode, run the following command:
+
+```shell
+ddev cypress:run
+```
+
+This command also accepts arguments. Refer to [#cypress run](https://docs.cypress.io/guides/guides/command-line#cypress-run) page for a full list of available arguments.
+
+Example: To run all Cypress tests, using Chrome in headless mode
+
+```shell
+ddev cypress:run --browser chrome
+```
+
+## Notes
+
+- The dockerized Cypress *should* find any locally installed plugins in your project's `node_modules`.
+- Some plugins may require additional settings, such as environmental variables. These can be passed through via command arguments.
+
+## Troubleshooting
+
+### "Could not find a Cypress configuration file, exiting"
+
+Cypress expects a directory strutures containing the tests, plugins and support files.
+
+- If the `./cypress` directory does not exist, it will scaffold out these directories, including a default `cypress.json` setting file and example tests when you first run `ddev cypress:open`.
+- Make sure you have a `cypress.json` file in your project root, or use `--config [file]` argument to specify one.
+
+### "Unable to open X display."
+
+- This recipe forwards the Cypress GUI via an X11  server. Please ensure you have this working on your host system.
+- For Windows 10 users, try [GWSL](https://opticos.github.io/gwsl/tutorials/manual.html) (via [Microsoft store](ms-windows-store://pdp/?productid=9NL6KD1H33V3)), or [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (via [chocolatey](https://community.chocolatey.org/packages/vcxsrv#versionhistory))

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -92,3 +92,5 @@ Cypress expects a directory strutures containing the tests, plugins and support 
 
 - This recipe forwards the Cypress GUI via an X11  server. Please ensure you have this working on your host system.
 - For Windows 10 users, try [GWSL](https://opticos.github.io/gwsl/tutorials/manual.html) (via [Microsoft store](ms-windows-store://pdp/?productid=9NL6KD1H33V3)), or [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (via [chocolatey](https://community.chocolatey.org/packages/vcxsrv#versionhistory))
+
+**Contributed by [@tyler36](https://github.com/tyler36)**

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -3,8 +3,8 @@
 - [Steps](#steps)
   - [A note about the Cypress image](#a-note-about-the-cypress-image)
 - [Commands](#commands)
-  - [`cypress:open`](#cypressopen)
-  - [`cypress:run`](#cypressrun)
+  - [`cypress-open`](#cypress-open)
+  - [`cypress-run`](#cypress-run)
 - [Notes](#notes)
 - [Troubleshooting](#troubleshooting)
   - ["Could not find a Cypress configuration file, exiting"](#could-not-find-a-cypress-configuration-file-exiting)
@@ -42,12 +42,12 @@ It is considered best practice to use a [specific image tag](https://github.com/
 Cypress can run into 2 different modes: interactive and runner.
 This recipe includes 2 alias commands to help you use Cypress.
 
-### `cypress:open`
+### `cypress-open`
 
 To open cypress in "interactive" mode, run the following command:
 
 ```shell
-ddev cypress:open
+ddev cypress-open
 ```
 
 This command also accepts arguments. Refer to the ["#cyress open" documentation](https://docs.cypress.io/guides/guides/command-line#cypress-open) for further details.
@@ -55,15 +55,15 @@ This command also accepts arguments. Refer to the ["#cyress open" documentation]
 Example: To open Cypress in interactive mode, and specify a config file
 
 ```shell
-ddev cypress:open --config cypress.json
+ddev cypress-open --config cypress.json
 ```
 
-### `cypress:run`
+### `cypress-run`
 
 To run Cypress in "runner" mode, run the following command:
 
 ```shell
-ddev cypress:run
+ddev cypress-run
 ```
 
 This command also accepts arguments. Refer to [#cypress run](https://docs.cypress.io/guides/guides/command-line#cypress-run) page for a full list of available arguments.
@@ -71,7 +71,7 @@ This command also accepts arguments. Refer to [#cypress run](https://docs.cypres
 Example: To run all Cypress tests, using Chrome in headless mode
 
 ```shell
-ddev cypress:run --browser chrome
+ddev cypress-run --browser chrome
 ```
 
 ## Notes
@@ -85,7 +85,7 @@ ddev cypress:run --browser chrome
 
 Cypress expects a directory strutures containing the tests, plugins and support files.
 
-- If the `./cypress` directory does not exist, it will scaffold out these directories, including a default `cypress.json` setting file and example tests when you first run `ddev cypress:open`.
+- If the `./cypress` directory does not exist, it will scaffold out these directories, including a default `cypress.json` setting file and example tests when you first run `ddev cypress-open`.
 - Make sure you have a `cypress.json` file in your project root, or use `--config [file]` argument to specify one.
 
 ### "Unable to open X display."

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -1,4 +1,4 @@
-# Intergrate Cypress (E2E testing) <!-- omit in toc -->
+# Integrate Cypress (E2E testing) <!-- omit in toc -->
 
 - [Steps](#steps)
   - [A note about the Cypress image](#a-note-about-the-cypress-image)

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -1,6 +1,9 @@
 # Integrate Cypress (E2E testing) <!-- omit in toc -->
 
 - [Steps](#steps)
+  - [Configure `DISPLAY`](#configure-display)
+    - [Windows 10](#windows-10)
+      - [Running DDEV on Win10 (not WSL)](#running-ddev-on-win10-not-wsl)
   - [A note about the Cypress image](#a-note-about-the-cypress-image)
 - [Commands](#commands)
   - [`cypress-open`](#cypress-open)
@@ -17,12 +20,47 @@ This recipe integrates a Cypress docker image with your DDEV project.
 ## Steps
 
 - Copy the `docker-compose.cypress.yaml` file into your project's `./.ddev' directory.
-- Copy the `commands` directory into your project's `./.ddev/commands` directory
+- Copy the `commands` directory into your project's `./.ddev/commands` directory.
 - Restart DDEV to begin using the this service.
 
     ```shell
     ddev restart
     ```
+
+### Configure `DISPLAY`
+
+To correctly display the Cypress screen and browser output, you must configure a `DISPLAY` environment variable.
+
+#### Windows 10
+
+If you are running DDEV on Win10 or WSL2 on Win10, you need to configure a display server on Win10.
+You are free to use any X11-compatible server. A configuration-free solution is to install [GWSL via the Windows Store](https://www.microsoft.com/en-us/p/gwsl/9nl6kd1h33v3#activetab=pivot:overviewtab).
+
+##### Running DDEV on Win10 (not WSL)
+
+- Install [GWSL via the Windows Store](https://www.microsoft.com/en-us/p/gwsl/9nl6kd1h33v3#activetab=pivot:overviewtab)
+- Get you "IPv4 Address" for your "Ethernet adapter" via networking panel or by typing `ipconfig` in a terminal. The address in the below example is `192.168.0.196`
+
+```shell
+❯ ipconfig
+
+Windows IP Configuration
+
+
+Ethernet adapter Ethernet:
+
+   Connection-specific DNS Suffix  . :
+   IPv4 Address. . . . . . . . . . . : 192.168.0.196
+   Subnet Mask . . . . . . . . . . . : 255.255.255.0
+   Default Gateway . . . . . . . . . : 192.168.0.1
+```
+
+- In your project `./docker-compose.cypress.yaml`, add the IPv4 address and `:0` (EG. `192.168.0.196:0` ) to the display section under environment.
+
+```yaml
+    environment:
+      - DISPLAY=192.168.0.196:0
+```
 
 ### A note about the Cypress image
 

--- a/docker-compose-services/cypress/README.md
+++ b/docker-compose-services/cypress/README.md
@@ -128,7 +128,7 @@ Cypress expects a directory strutures containing the tests, plugins and support 
 
 ### "Unable to open X display."
 
-- This recipe forwards the Cypress GUI via an X11  server. Please ensure you have this working on your host system.
+- This recipe forwards the Cypress GUI via an X11 / X410 server. Please ensure you have this working on your host system.
 - For Windows 10 users, try [GWSL](https://opticos.github.io/gwsl/tutorials/manual.html) (via [Microsoft store](ms-windows-store://pdp/?productid=9NL6KD1H33V3)), or [VcXsrv](https://sourceforge.net/projects/vcxsrv/) (via [chocolatey](https://community.chocolatey.org/packages/vcxsrv#versionhistory))
 
 **Contributed by [@tyler36](https://github.com/tyler36)**

--- a/docker-compose-services/cypress/commands/cypress/cypress-open
+++ b/docker-compose-services/cypress/commands/cypress/cypress-open
@@ -2,7 +2,7 @@
 
 ## Description: Open an interactive Cypress window
 ##              https://docs.cypress.io/guides/guides/command-line#cypress-open
-## Usage: cypress:open [arguments]
-## Example: "ddev cypress:open --config cypress.json"
+## Usage: cypress-open [arguments]
+## Example: "ddev cypress-open --config cypress.json"
 
 cypress open --project . "$@"

--- a/docker-compose-services/cypress/commands/cypress/cypress-open
+++ b/docker-compose-services/cypress/commands/cypress/cypress-open
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: Open an interactive Cypress window
+##              https://docs.cypress.io/guides/guides/command-line#cypress-open
+## Usage: cypress:open [arguments]
+## Example: "ddev cypress:open --config cypress.json"
+
+cypress open --project . "$@"

--- a/docker-compose-services/cypress/commands/cypress/cypress-run
+++ b/docker-compose-services/cypress/commands/cypress/cypress-run
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: Use Cypress in "runner" mode.
+##              
+## Usage: cypress:run [arguments]
+## Example: "ddev cypress:run --browser chrome"
+
+cypress run "$@"

--- a/docker-compose-services/cypress/commands/cypress/cypress-run
+++ b/docker-compose-services/cypress/commands/cypress/cypress-run
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ## Description: Use Cypress in "runner" mode.
-##              
-## Usage: cypress:run [arguments]
-## Example: "ddev cypress:run --browser chrome"
+##
+## Usage: cypress-run [arguments]
+## Example: "ddev cypress-run --browser chrome"
 
 cypress run "$@"

--- a/docker-compose-services/cypress/docker-compose.cypress.yaml
+++ b/docker-compose-services/cypress/docker-compose.cypress.yaml
@@ -1,0 +1,32 @@
+version: '3.6'
+services:
+  cypress:
+    image: cypress/included:8.6.0
+    container_name: ddev-${DDEV_SITENAME}-cypress
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    user: '$DDEV_UID:$DDEV_GID'
+    tty: true
+    ipc: host
+    links:
+      - web:web
+
+    environment:
+      - CYPRESS_baseUrl=$DDEV_PRIMARY_URL
+      - DISPLAY
+
+    volumes:
+      # Mount the project to Cypress's project point
+      - "${DDEV_APPROOT}:/e2e"
+      # Mount DDEV to allow commands
+      - ".:/mnt/ddev_config"
+      # Allow X11 forwarding
+      - /tmp/.X11-unix:/tmp/.X11-unix
+
+    external_links:
+      # Resolve links via DDEV router
+      - "ddev-router:${DDEV_HOSTNAME}"
+
+    entrypoint: /bin/bash
+    working_dir: /e2e

--- a/docker-compose-services/cypress/docker-compose.cypress.yaml
+++ b/docker-compose-services/cypress/docker-compose.cypress.yaml
@@ -8,8 +8,6 @@ services:
       com.ddev.approot: ${DDEV_APPROOT}
     user: "${DDEV_UID}:${DDEV_GID}"
     tty: true
-    links:
-      - web:web
 
     environment:
       - CYPRESS_baseUrl=${DDEV_PRIMARY_URL}

--- a/docker-compose-services/cypress/docker-compose.cypress.yaml
+++ b/docker-compose-services/cypress/docker-compose.cypress.yaml
@@ -5,15 +5,16 @@ services:
     container_name: ddev-${DDEV_SITENAME}-cypress
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: $DDEV_APPROOT
-    user: '$DDEV_UID:$DDEV_GID'
+      com.ddev.approot: ${DDEV_APPROOT}
+    user: "${DDEV_UID}:${DDEV_GID}"
     tty: true
     ipc: host
     links:
       - web:web
 
     environment:
-      - CYPRESS_baseUrl=$DDEV_PRIMARY_URL
+      - CYPRESS_baseUrl=${DDEV_PRIMARY_URL}
+      # Win10 requires HOST's actual IP ADDRESS
       - DISPLAY
 
     volumes:
@@ -21,8 +22,6 @@ services:
       - "${DDEV_APPROOT}:/e2e"
       # Mount DDEV to allow commands
       - ".:/mnt/ddev_config"
-      # Allow X11 forwarding
-      - /tmp/.X11-unix:/tmp/.X11-unix
 
     external_links:
       # Resolve links via DDEV router

--- a/docker-compose-services/cypress/docker-compose.cypress.yaml
+++ b/docker-compose-services/cypress/docker-compose.cypress.yaml
@@ -8,7 +8,6 @@ services:
       com.ddev.approot: ${DDEV_APPROOT}
     user: "${DDEV_UID}:${DDEV_GID}"
     tty: true
-    ipc: host
     links:
       - web:web
 


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
This recipe integrates the Cypress E2E testing tool.

Using Cypress, you can:
- test website in multuple *real* browser versions
- create screenshots and video when tests fails
- create visual regression tests (requires plugin)

I've been using this in WSL2 for a few days without a problem. 

## Testing

I created a public repo for demo purposes https://github.com/tyler36/ddev-cypress .

1. Clone the repo
2. Start ddev
3. Run cypress commands

- Note: The image runs as root, so there was a permission issue when it created files. I think I resolved it, but confirmation would be appreciated.

## TODO
- [ ] X11 setup reference for Mac
- [ ] X11 setup reference for Linux
- [ ] document Win10 setup

Not sure how to handle X11. We probably don't want to be troubleshooting its installation.

## Related Issue Link(s):

