### PR TITLE
Remove unneeded / duplicate links statement in docker-compose.selenium.yaml

### DIFF
--- a/docker-compose-services/drupal8-behat-selenium/docker-compose.selenium.yaml
+++ b/docker-compose-services/drupal8-behat-selenium/docker-compose.selenium.yaml
@@ -5,9 +5,6 @@ services:
     depends_on:
     - db
     - selenium
-    links:
-    - db:db
-    - selenium:selenium
   selenium:
     container_name: ddev-${DDEV_SITENAME}-selenium
     image: selenium/standalone-chrome-debug:3.13.0-argon


### PR DESCRIPTION
Update docker-compose.selenium.yaml to remove duplicate/needed links statement. This can cause duplication issues with docker-compose v2.

## The New Solution/Problem/Issue/Bug:

The file docker-compose.selenium.yaml includes a `links` statement for the `web` service. This is a duplicates what the base is doing when creating the web service. This causes a duplication when the .ddev-docker-compose-full.yaml is created and can cause the `ddev start` command to fail.

## How this PR Solves The Problem:

This PR removes the uneeded `links` statement from the docker-compose.selenium.yaml file.

## Manual Testing Instructions:

1. Include updated docker-compose.selenium.yaml file in your .ddev directory.
1.  Run `ddev start`
    * Confirm that ddev starts with no errors
1. Review content of .ddev-docker-compose-full.yaml 
    * Confirm the `services.web.links` statement does not include a duplicate `- db:db` statement.

## Related Issue Link(s):
See https://drupal.slack.com/archives/C5TQRQZRR/p1635866660204500
