### PR TITLE
Add MinIO Docker Compose Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ General information on how to do additional services and some additional example
 * [Elastichq](docker-compose-services/elastichq)
 * [Headless Chrome for Behat Testing](docker-compose-services/headless-chrome)
 * [Kibana](docker-compose-services/kibana)
+* [MinIO](docker-compose-services/minio/)
 * [MongoDB](docker-compose-services/mongodb/)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [PHP 8.1](docker-compose-services/php8_1) While it's in prerelease

--- a/docker-compose-services/minio/README.md
+++ b/docker-compose-services/minio/README.md
@@ -1,0 +1,63 @@
+# MinIO
+
+This recipe adds a [MinIO](https://min.io/) container to a project.
+
+[MinIO](https://min.io/) is a S3 compatible object-storage.
+It can be used, to run an S3 instance locally, in case the hosted S3 is not reachable (like developing while offline)
+
+## Installation
+
+* Copy the `docker-compose.minio.yaml` file to your project's DDEV root folder (`.ddev/docker-compose.minio.yaml`)
+* Copy the `minio-build` folder to your project's DDEV root folder (`.ddev/minio-build`)
+* Copy the `commands/minio` directory to the commands folder of your project's DDEV commands folder (`.ddev/commands/minio/mc`) and make sure it's executable, `chmod +x .ddev/commands/minio/mc`.
+* Start (or restart) DDEV to have the service initialized: `ddev start`
+
+## Connection
+* MinIO is available at `ddev-<projectname>-minio:9000` **inside the containers** and at `https://<projectname>.ddev.site:9000` **outside the containers**
+* If `https://<projectname>.ddev.site:9000` is opened in the browser, it will redirect to the object browser
+
+## Configuration
+The server is configured through the environment variables in `docker-compose.minio.yaml`
+Default credentials (for API and  object browser):
+* MINIO_ACCESS_KEY=minio
+* MINIO_SECRET_KEY=minio123
+
+> By default, all the files managed by MinIO will be stored in a persistent Volume with the name `<projectname>-minio`.
+> This volume will not be deleted automatically by DDEV when deleting your project. You will need to delete it manually!
+
+## Additional configuration
+The MinIO container does have `mc` ([MinIO Client](https://docs.min.io/docs/minio-client-quickstart-guide)) already present. But it is not configured out of the box.
+You will need to configure it manually and create your bucket!
+This can be done by performing the following commands:
+
+```bash
+ddev mc alias set local http://localhost:9000 minio minio123  # Configure the local alias in mc 
+ddev mc mb minio/default -p # Create a bucket named "default"
+mc policy set download minio/default # Set the bucket policy to download
+```
+> If you have changed the default access key and/or secret, you will need to use these values in the commands
+
+Alternatively, you could do this automatically with a post-start [hook](https://ddev.readthedocs.io/en/stable/users/extending-commands/)
+Example:
+```yaml
+hooks:
+  post-start:
+    - exec: "mc alias set local http://localhost:9000 minio minio123"
+      service: minio
+    - exec: "mc mb minio/default -p"
+      service: minio
+    - exec: "mc policy set download minio/default"
+      service: minio
+```
+> You can find these hooks in example.hooks.yaml
+
+## Alternative clients
+MinIO's API is fully compatible to Amazon S3 and besides mc ([MinIO Client](https://docs.min.io/docs/minio-client-quickstart-guide)) it can be used with other supported clients like [aws-cli](https://docs.min.io/docs/aws-cli-with-minio), [s3cmd](https://docs.min.io/docs/s3cmd-with-minio) 
+
+## Additional links
+[MinIO Documentation](https://docs.min.io/)
+[MinIO Docker image](https://hub.docker.com/r/minio/minio)
+[MinIO Client Docker image](https://hub.docker.com/r/minio/mc)
+[ddev Hooks](https://ddev.readthedocs.io/en/stable/users/extending-commands/)
+
+**Contributed by [@NBZ4live](https://github.com/NBZ4live)**

--- a/docker-compose-services/minio/commands/minio/mc
+++ b/docker-compose-services/minio/commands/minio/mc
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: run minio client in minio container
+## Usage: mc [FLAGS] COMMAND [COMMAND FLAGS | -h] [ARGUMENTS...]
+## Example: "ddev mc" or "ddev mc ls local"
+
+mc $@

--- a/docker-compose-services/minio/docker-compose.minio.yaml
+++ b/docker-compose-services/minio/docker-compose.minio.yaml
@@ -1,0 +1,36 @@
+version: '3.6'
+
+services:
+  minio:
+    container_name: ddev-${DDEV_SITENAME}-minio
+    build:
+      context: './minio-build'
+    restart: always
+    ports:
+      - 9000
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9001:9000
+      - HTTPS_EXPOSE=9000:9000
+      - MINIO_ACCESS_KEY=minio
+      - MINIO_SECRET_KEY=minio123
+    command: server /data
+    volumes:
+      - type: "volume"
+        source: minio
+        target: "/data"
+        volume:
+          nocopy: true
+      - type: "bind"
+        source: "."
+        target: "/mnt/ddev_config"
+  web:
+    links:
+      - minio:$DDEV_HOSTNAME
+
+volumes:
+  minio:
+    name: "${DDEV_SITENAME}-minio"

--- a/docker-compose-services/minio/example.hooks.yaml
+++ b/docker-compose-services/minio/example.hooks.yaml
@@ -1,0 +1,14 @@
+# Many ddev commands can be extended to run tasks before or after the
+# ddev command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+hooks:
+  post-start:
+    - exec: "mc alias set local http://localhost:9000 minio minio123"
+      service: minio
+    - exec: "mc mb minio/default -p"
+      service: minio
+    - exec: "mc policy set download minio/default"
+      service: minio

--- a/docker-compose-services/minio/minio-build/Dockerfile
+++ b/docker-compose-services/minio/minio-build/Dockerfile
@@ -1,0 +1,9 @@
+FROM minio/minio:latest
+
+COPY --from=minio/mc:latest /usr/bin/mc /usr/bin/mc
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
+VOLUME ["/data"]
+
+CMD ["minio"]


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
This recipe adds a [MinIO](https://min.io/) container to a project.

[MinIO](https://min.io/) is a S3 compatible object-storage.
It can be used, to run an S3 instance locally, in case the hosted S3 is not reachable (like developing while offline)


## Manual Testing Instructions:
Follow the instructions from `docker-compose-services/minio/README.md`.
Expected result:
* A working MinIO instance is available in the project.
* The object browser is available at `https://<projectname>.ddev.site:9000`.
* All files uploaded through the object browser can be listed with `ddev exec -s minio ls -al /data/default`