### PR TITLE
Review projects to make sure they use ddev-<project>-service

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -22,7 +22,7 @@ services:
       # In order for the system to work, one of these must be uncommented so
       # that the test system can connect to the database.
       # - SIMPLETEST_DB=sqlite://tmp/test.sqlite
-      # - SIMPLETEST_DB=mysql://db:db@db:3306/db
+      # - SIMPLETEST_DB=mysql://ddev-<project>-db:db@db:3306/db
       #
       # Note: Do not modify the base URL value.
       - SIMPLETEST_BASE_URL=http://web

--- a/docker-compose-services/mongodb/README.md
+++ b/docker-compose-services/mongodb/README.md
@@ -18,7 +18,7 @@ Steps to follow:
 4. In your application `.env`, set the connection string:
 
     ```
-    MONGODB_URL=mongodb://db:db@mongo:27017
+    MONGODB_URL=mongodb://db:db@ddev-<project>-mongo:27017
     MONGODB_DB=api
     ```
 

--- a/docker-compose-services/php8_1/README.md
+++ b/docker-compose-services/php8_1/README.md
@@ -1,6 +1,6 @@
 # PHP8.1 (while in alpha/beta/etc)
 
-# NOTE: php8.1 is now included in DDEV v1.18.0-rc1+, so you probably don't need this.
+# NOTE: php8.1 is now included in DDEV v1.18.0+, so you probably don't need this.
 
 DDEV-Local will directly support PHP 8.1 as soon as possible, but not likely until the full release in late 2021. At that time this recipe will be obsolete.
 

--- a/docker-compose-services/redis-commander/README.md
+++ b/docker-compose-services/redis-commander/README.md
@@ -13,7 +13,7 @@ Redis Commander requires that there is a container within the project that has a
 If your redis server is not available on host `redis` on port `6379`, then you need to edit `docker-compose.redis-commander.yaml` and edit the following environment variables:
 
 * Change `REDIS_PORT` to the port your redis server is available at.
-* Change `REDIS_HOST` to the hostname your redis server is available at.
+* Change `REDIS_HOST` to `ddev-<project>-redis`.
 
 ## Installation
 

--- a/docker-compose-services/solr-4/README.md
+++ b/docker-compose-services/solr-4/README.md
@@ -15,7 +15,7 @@ To enable Solr in your project follow these steps:
 
 You now have a running Solr instance for your project. To get the URL for the instance run `ddev describe`.
 
-By default the Solr core is named "dev" and the host is named "solr" so applications running inside the web container will be able to access the Solr service at `http://solr:8983`; an alternative format will be displayed via `ddev describe`, e.g. `http://myproject.ddev.site:8983`.
+By default the Solr core is named "dev" and the host is named "solr" so applications running inside the web container will be able to access the Solr service at `http://ddev-<project>-solr:8983`; this is also displayed by `ddev describe`.
 
 ## Creating search indexes
 
@@ -57,13 +57,9 @@ the expected URL format, the Solr index may not have been created correctly. It
 is possible to access Solr directly from the host OS by loading its full URL,
 e.g. `http://myproject.ddev.site:8983`.
 
-* The brower may redirect to https://myproject.ddev.site:8983. This is a
+* The browser may redirect to https://myproject.ddev.site:8983. This is a
   default behavior in Safari. The solution is to either load the page in a
-  different browser, e.g. Firefox, or load the site from the HTTPS port:
-  https://myproject.ddev.site:8984
-* If https://myproject.ddev.site:8984 does not work make sure that the
-  `HTTPS_EXPOSE=8984` line is present in the `docker-compose.solr.yml` file,
-  per the example in this directory.
+  different browser, e.g. Firefox.
 
 Once http://myproject.ddev.site:8983 or http://myproject.ddev.site:8984 loads
 correctly it will redirect the browser to

--- a/docker-compose-services/solr-4/docker-compose.solr.yml
+++ b/docker-compose-services/solr-4/docker-compose.solr.yml
@@ -22,7 +22,6 @@ services:
       # This defines the ports the service should be accessible from at
       # sitename.ddev.site.
       - HTTP_EXPOSE=8983
-      - HTTPS_EXPOSE=8984:8983
     volumes:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears

--- a/docker-compose-services/solr-5/README.md
+++ b/docker-compose-services/solr-5/README.md
@@ -81,13 +81,9 @@ the expected URL format, the Solr index may not have been created correctly. It
 is possible to access Solr directly from the host OS by loading its full URL,
 e.g. `http://myproject.ddev.site:8983`.
 
-* The brower may redirect to https://myproject.ddev.site:8983. This is a
+* The browser may redirect to https://myproject.ddev.site:8983. This is a
   default behavior in Safari. The solution is to either load the page in a
-  different browser, e.g. Firefox, or load the site from the HTTPS port:
-  https://myproject.ddev.site:8984
-* If https://myproject.ddev.site:8984 does not work make sure that the
-  `HTTPS_EXPOSE=8984` line is present in the `docker-compose.solr.yml` file,
-  per the example in this directory.
+  different browser, e.g. Firefox.
 
 Once http://myproject.ddev.site:8983 or http://myproject.ddev.site:8984 loads
 correctly it will redirect the browser to

--- a/docker-compose-services/solr-5/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-5/docker-compose.solr.yaml
@@ -47,7 +47,6 @@ services:
       # This defines the ports the service should be accessible from at
       # sitename.ddev.site.
       - HTTP_EXPOSE=8983
-      - HTTPS_EXPOSE=8984:8983
     volumes:
       # solr core *data* is stored on the 'solr_var' or `solr_opt` docker
       # volumes depending on the version of solr.

--- a/docker-compose-services/solr-7/README.md
+++ b/docker-compose-services/solr-7/README.md
@@ -70,18 +70,9 @@ the expected URL format, the Solr index may not have been created correctly. It
 is possible to access Solr directly from the host OS by loading its full URL,
 e.g. `http://myproject.ddev.site:8983`.
 
-* The brower may redirect to https://myproject.ddev.site:8983. This is a
-  default behavior in Safari. The solution is to either load the page in a
-  different browser, e.g. Firefox, or load the site from the HTTPS port:
-  https://myproject.ddev.site:8984
-* If https://myproject.ddev.site:8984 does not work make sure that the
-  `HTTPS_EXPOSE=8984` line is present in the `docker-compose.solr.yml` file,
-  per the example in this directory.
-
-Once http://myproject.ddev.site:8983 or http://myproject.ddev.site:8984 loads
+Once http://myproject.ddev.site:8983 loads
 correctly it will redirect the browser to
-http://myproject.ddev.site:8983/solr/#/ or
-https://myproject.ddev.site:8984/solr/#/, which is the main dashboard page for
+http://myproject.ddev.site:8983/solr/#/ which is the main dashboard page for
 Solr. From here it is possible to see how much memory and swap space the system
 is using.
 

--- a/docker-compose-services/solr-7/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-7/docker-compose.solr.yaml
@@ -47,9 +47,6 @@ services:
       # HTTP_EXPOSE exposes http traffic from the container port 8983
       # to the host port 8983 vid ddev-router reverse proxy.
       - HTTP_EXPOSE=8983:8983
-      # HTTPS_EXPOSE exposes https traffic from the container port 8983
-      # to the host port 8984 vid ddev-router reverse proxy.
-      - HTTPS_EXPOSE=8984:8983
     volumes:
       # solr core *data* is stored on the 'solr' docker volume
       # This mount is optional; without it your search index disappears


### PR DESCRIPTION


## The New Solution/Problem/Issue/Bug:

There were some projects that used the ambiguous service-name-as-hostname, which is sometimes but not always supported by docker-compose.

## How this PR Solves The Problem:

Try to change them all to `ddev-<project>-<servicename>`

