### PR TITLE
Add command to stop all projects except current

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 * [Executing Symfony console and phpunit commands without ssh](custom-commands/symfony/)
 * [Build Drupal theme assets with Gulp](custom-commands/gulp) -- with minor modifications, this approach will work for other frameworks (WordPress, etc.) and other front-end build tools.
 * [Run Laravel `tinker` or Drupal's `drush php` with a single command](custom-commands/tinker)
+* [Stop all running projects except the current](custom-commands/stop-other)
 
 ## Additional services added via docker-compose.\<service\>.yaml
 

--- a/custom-commands/stop-other/README.md
+++ b/custom-commands/stop-other/README.md
@@ -4,5 +4,7 @@ Copy the [stop-other](./stop-other) command to the .ddev/commands/host/ director
 
 Now you can run `ddev stop-other` to stop all running projects except the one you are calling the command from.
 
+This requires that the `jq` command be installed. `brew install jq` or see https://stedolan.github.io/jq/download/
+
 **Original idea by sceo (on Discord) and code by [@rfay](https://github.com/rfay)**
 

--- a/custom-commands/stop-other/README.md
+++ b/custom-commands/stop-other/README.md
@@ -1,0 +1,8 @@
+# Stops all running projects except the current.
+
+Copy the [stop-other](./stop-other) command to the .ddev/commands/host/ directory or the global ~/.ddev/commands/host directory (to make it work for all projects).
+
+Now you can run `ddev stop-other` to stop all running projects except the one you are calling the command from.
+
+**Original idea by sceo (on Discord) and code by [@rfay](https://github.com/rfay)**
+

--- a/custom-commands/stop-other/stop-other
+++ b/custom-commands/stop-other/stop-other
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Description: Stop all other running projects
+## Usage: stop-other
+## Example: "ddev stop-other"
+
+# Ensure jq is installed on the host.
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed. See https://stedolan.github.io/jq/download/ for installation instructions."; exit 1; }
+
+# Stop all other running projects.
+ddev stop $(ddev list --active-only -j | jq -r ".raw[].name" | grep -v $(ddev describe -j | jq -r ".raw.name"))


### PR DESCRIPTION
The idea came up on Discord by @sceo (see https://discord.com/channels/664580571770388500/689166305315520541/915724577261359104).

Original question:

> Is there a way to stop all running ddev projects except the one you're currently in?

@rfay came up with a handy one-liner utilizing `jq` that is added as a custom command here.