### PR TITLE
✨ feat: add a command to disable / enable a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 * [Build Drupal theme assets with Gulp](custom-commands/gulp) -- with minor modifications, this approach will work for other frameworks (WordPress, etc.) and other front-end build tools.
 * [Run Laravel `tinker` or Drupal's `drush php` with a single command](custom-commands/tinker)
 * [Stop all running projects except the current](custom-commands/stop-other)
+* [Dynamically enable / disable a service](custom-commands/dynamic-service)
 
 ## Additional services added via docker-compose.\<service\>.yaml
 

--- a/custom-commands/dynamic-service/readme.md
+++ b/custom-commands/dynamic-service/readme.md
@@ -1,0 +1,44 @@
+# Dynamically enable / disable a service
+
+Have you ever wanted to enable a serivce locally, but not on you CI?
+Need to quickly disable a service for debugging?
+
+This handle little command lets you enable/disable a DDEV `docker-compose` based service.
+
+## Installation
+
+- Copy the `service` file into the DDEV commands directory.
+
+To activate the command for all DDEV projects, copy it to your global DDEV config directory: `~/.ddev/commands/host`.
+
+If you prefer to enable it on a per-project basis, copy it into the project commands directory: `./.ddev/commands/host`.
+
+Note: If you have a copy in both locations, you will recieve a warning:
+
+```shell
+Project-level command 'service' is overriding the global 'service' command
+```
+
+## Usage
+
+EG. Lets assume you have  `./.ddev/docker-compose.cypress.yaml` file that provides the `cypress` service.
+
+Type the following command to disable the service:
+
+```shell
+ddev service cypress disable
+```
+
+The file is renamed to `./.ddev/docker-compose.cypress.yaml.disabled`. It will no longer be read by DDEV on startup.
+
+Type the following command to enable the service:
+
+```shell
+ddev service cypress enable
+ddev restart
+```
+
+## Notes
+
+- The service name is parsed from the file name; `docker-composer.goo.yaml` assumes the service is called `goo`.
+- You can update the command variable `DISABLED_EXT` to change the disabled extension. Default is ".`disabled`"

--- a/custom-commands/dynamic-service/readme.md
+++ b/custom-commands/dynamic-service/readme.md
@@ -42,3 +42,5 @@ ddev restart
 
 - The service name is parsed from the file name; `docker-composer.goo.yaml` assumes the service is called `goo`.
 - You can update the command variable `DISABLED_EXT` to change the disabled extension. Default is ".`disabled`"
+
+**Contributed by [@tyler36](https://github.com/tyler36)**

--- a/custom-commands/dynamic-service/readme.md
+++ b/custom-commands/dynamic-service/readme.md
@@ -27,7 +27,6 @@ Type the following command to disable the service:
 
 ```shell
 ddev service cypress disable
-ddev restart
 ```
 
 The file is renamed to `./.ddev/docker-compose.cypress.yaml.disabled`. It will no longer be read by DDEV on startup.
@@ -36,11 +35,11 @@ Type the following command to enable the service:
 
 ```shell
 ddev service cypress enable
-ddev restart
 ```
 
 ## Notes
 
+- If a service is updated, "enabled" or "disabled", DDEV will automatically restart to apply the changes.
 - The service name is parsed from the file name; `docker-composer.goo.yaml` assumes the service is called `goo`.
 - You can update the command variable `DISABLED_EXT` to change the disabled extension. Default is ".`disabled`"
 

--- a/custom-commands/dynamic-service/readme.md
+++ b/custom-commands/dynamic-service/readme.md
@@ -27,6 +27,7 @@ Type the following command to disable the service:
 
 ```shell
 ddev service cypress disable
+ddev restart
 ```
 
 The file is renamed to `./.ddev/docker-compose.cypress.yaml.disabled`. It will no longer be read by DDEV on startup.

--- a/custom-commands/dynamic-service/service
+++ b/custom-commands/dynamic-service/service
@@ -54,4 +54,5 @@ case $2 in
     ;;
 esac
 
-echo "DDEV '$1' has been ${TARGET}. Please type `ddev restart` to re-initalize and apply the changes."
+echo "DDEV '$1' has been ${TARGET}."
+ddev restart

--- a/custom-commands/dynamic-service/service
+++ b/custom-commands/dynamic-service/service
@@ -10,6 +10,15 @@ DISABLED_EXT="disabled"
 STATUS=null
 FILE="./.ddev/docker-compose.$1.yaml"
 
+list_services() {
+    ddev describe
+    exit 0;
+}
+
+if [[ "$1" == "status" ]] || [ -z "$1" ]; then
+    list_services
+fi
+
 if [ -f "${FILE}" ]; then
     STATUS="enabled"
 fi
@@ -24,6 +33,7 @@ if [ -z "${STATUS}" ]; then
     exit 0
 fi
 
+if
 echo "DDEV '$1' service is currently ${STATUS}."
 
 case $2 in
@@ -44,9 +54,6 @@ case $2 in
     fi
 
     mv "${FILE}" "${FILE}.${DISABLED_EXT}"
-    ;;
-    status)
-        echo $result
     ;;
     *)
         echo "Invalid argument: $2"

--- a/custom-commands/dynamic-service/service
+++ b/custom-commands/dynamic-service/service
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+## Description: This allows DDEV services activated via docker-compose to be enabled/disabled
+## Usage: service [service-name] [status]
+## Example: To enable a service: "ddev service postgres enable", "ddev service postgres on"
+## Example: To disable a service: "ddev service postgres disable", "ddev service postgres off"
+
+
+DISABLED_EXT="disabled"
+STATUS=null
+FILE="./.ddev/docker-compose.$1.yaml"
+
+if [ -f "${FILE}" ]; then
+    STATUS="enabled"
+fi
+
+if [ -f "${FILE}.${DISABLED_EXT}" ]; then
+    STATUS="disabled"
+fi
+
+if [ -z "${STATUS}" ]; then
+    echo "DDEV '$1' was not detected"
+    echo "Are you sure you have ${FILE} file?"
+    exit 0
+fi
+
+echo "DDEV '$1' service is currently ${STATUS}."
+
+case $2 in
+    on|true|enable)
+    TARGET="enabled"
+    if [ "${STATUS}" = "${TARGET}" ]; then
+        echo "Nothing to do"
+        exit 0
+    fi
+
+    mv "${FILE}.${DISABLED_EXT}" "${FILE}"
+    ;;
+    off|false|disable)
+    TARGET="disabled"
+    if [ "${STATUS}" = "${TARGET}" ]; then
+        echo "Nothing to do."
+        exit 0
+    fi
+
+    mv "${FILE}" "${FILE}.${DISABLED_EXT}"
+    ;;
+    status)
+        echo $result
+    ;;
+    *)
+        echo "Invalid argument: $2"
+        exit 0;
+    ;;
+esac
+
+echo "DDEV '$1' has been ${TARGET}. Please type `ddev restart` to re-initalize and apply the changes."

--- a/custom-commands/dynamic-service/service
+++ b/custom-commands/dynamic-service/service
@@ -27,7 +27,7 @@ fi
 echo "DDEV '$1' service is currently ${STATUS}."
 
 case $2 in
-    on|true|enable)
+    on|true|enable|start)
     TARGET="enabled"
     if [ "${STATUS}" = "${TARGET}" ]; then
         echo "Nothing to do"
@@ -36,7 +36,7 @@ case $2 in
 
     mv "${FILE}.${DISABLED_EXT}" "${FILE}"
     ;;
-    off|false|disable)
+    off|false|disable|stop)
     TARGET="disabled"
     if [ "${STATUS}" = "${TARGET}" ]; then
         echo "Nothing to do."


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug

There are some situtation where you might need to disable / enable a `docker-compose` service dynamically.

EG. I have a cypress service to uses a 2.8G image that is not required when using ddev-gitpod.
By having the service disabled, I can save bandwidth, time, and memory.

DDEV currently supports toggling XDebug on / off on the fly.

I consider this a WIP. It needs testing on Win & MacOs. 
After your help on Discord. I wanted to wip up something to use and get the conversion going.



## How this PR Solves The Problem

This PR enables a user to dynamically enable / disable a `docker-compose.yaml`-based service.

It does this by changing the `.yaml` file extension via a simple custom command.

Disabled files become: `docker-compose.cypress.yaml.disabled`
... which then changed back to `docker-compose.cypress.yaml` when enabled.

## Notes

- It assumes a naming convention for `docker-compose.yaml` files.
- It accepts _falsey_ values to disable: "disable", "off", "false"
- It accepts _truthy_ values to enable: "enable", "on", "true"

## Tested

- WSL2

## Related Issue Link(s):

[#3068](https://github.com/drud/ddev/issues/3068)