### PR TITLE
PostgreSQL commands: changed from `pgsql-db` directory to `import-db`

### DIFF
--- a/docker-compose-services/postgres/README.md
+++ b/docker-compose-services/postgres/README.md
@@ -32,8 +32,8 @@ When using multiple project with PostgreSQL support, remember to update your `do
 
 Two new `ddev` commands are provided:
 
-* `ddev pgsql_export` : Use `pg_dump` to export `db` to `.ddev/pgsql-db/postgresql.db.sql`
-* `ddev pgsql_import` : Use `pgsql` to import `.ddev/pgsql-db/postgresql.db.sql` into `db` - Note that this must be executed with an empty database.
+* `ddev pgsql_export` : Use `pg_dump` to export `db` to `.ddev/import-db/postgresql.db.sql`
+* `ddev pgsql_import` : Use `pgsql` to import `.ddev/import-db/postgresql.db.sql` into `db` - Note that this must be executed with an empty database.
 
 Example `config.yaml` hooks configuration to automatically import/export the `db` table:
 
@@ -50,7 +50,7 @@ hooks:
 ```
 
 There are also another non-plain-text formats that `pg_dump` can generate, and you might need to work with them. If that's the case, there is also
-a `ddev pg_restore` command that will restore `.ddev/pgsql-db/postgresql.db.dump` into `db`.
+a `ddev pg_restore` command that will restore `.ddev/import-db/postgresql.db.dump` into `db`.
 
 ## PostGIS
 

--- a/docker-compose-services/postgres/commands/postgres/pgsql_export
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_export
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-## Description: Dump the postgresql database to .ddev/pgsql-db/postgresql.db.sql
+## Description: Dump the postgresql database to .ddev/import-db/postgresql.db.sql
 ## Usage: pgsql_export
 ## Example: ddev pgsql_export
 
-mkdir -p /mnt/ddev_config/import-db && chmod 777 /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/pgsql-db/postgresql.db.sql"
+mkdir -p /mnt/ddev_config/import-db && chmod 777 /mnt/ddev_config/import-db && su postgres -c "pg_dump db --username=db --host=localhost --port=5432 --column-inserts > /mnt/ddev_config/import-db/postgresql.db.sql"

--- a/docker-compose-services/postgres/commands/postgres/pgsql_import
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_import
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Load to an empty postgresql database from .ddev/pgsql-db/postgresql.db.sql
+## Description: Load to an empty postgresql database from .ddev/import-db/postgresql.db.sql
 ## Usage: pgsql_import
 ## Example: ddev pgsql_import
 
@@ -8,4 +8,4 @@
 su postgres -c "psql -U db -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO db; GRANT ALL ON SCHEMA public TO public;'"
 
 # Import via user postgres to avoid credentials prompt
-su postgres -c "psql -U db db < /mnt/ddev_config/pgsql-db/postgresql.db.sql"
+su postgres -c "psql -U db db < /mnt/ddev_config/import-db/postgresql.db.sql"

--- a/docker-compose-services/postgres/commands/postgres/pgsql_restore
+++ b/docker-compose-services/postgres/commands/postgres/pgsql_restore
@@ -8,4 +8,4 @@
 su postgres -c "psql -U db -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO db; GRANT ALL ON SCHEMA public TO public;'"
 
 # Import via user postgres to avoid credentials prompt
-su postgres -c "pg_restore --no-owner -U db -d db /mnt/ddev_config/pgsql-db/postgresql.db.dump"
+su postgres -c "pg_restore --no-owner -U db -d db /mnt/ddev_config/import-db/postgresql.db.dump"


### PR DESCRIPTION
This PR fixes #183 by running the PostgreSQL export & import process entirely through the `import-db` directory.

The `import-db` has the advantage over the `pgsql-db` that it is already entered in the .gitignore file.