### PR TITLE
Service meilisearch v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ General information on how to do additional services and some additional example
 * [Elastichq](docker-compose-services/elastichq)
 * [Headless Chrome for Behat Testing](docker-compose-services/headless-chrome)
 * [Kibana](docker-compose-services/kibana)
+* [Meilisearch](docker-compose-services/meilisearch/)
 * [MongoDB](docker-compose-services/mongodb/)
 * [Old PHP Versions to run old sites](docker-compose-services/old_php)
 * [PHP 8.1](docker-compose-services/php8_1) While it's in prerelease

--- a/docker-compose-services/meilisearch/README.md
+++ b/docker-compose-services/meilisearch/README.md
@@ -1,0 +1,22 @@
+# Meilisearch
+
+Using official meilisearch v0.20.0 container [meilisearch](https://hub.docker.com/r/getmeili/meilisearch).
+
+## Installation
+
+Copy [docker-compose.meilisearch.yaml](docker-compose.meilisearch.yaml) to your project's .ddev folder.
+
+## Configuration
+
+From within the container, the meilisearch container is reached at hostname: ddev-<projectname>-meilisearch, port: 7700, so the server URL might be `http://ddev-<projectname>-meilisearch:7700`.
+
+## Connection
+
+You can access the Meilisearch server directly from the host for debugging purposes by visiting `http://<projectname>.ddev.site:7700`.
+
+You can use `ddev logs -s meilisearch` to investigate what the meilissearch daemon has been up to.
+
+## Additional Resources
+
+* https://www.drupal.org/project/search_api_meilisearch
+* https://docs.meilisearch.com/learn/getting_started/quick_start.html

--- a/docker-compose-services/meilisearch/README.md
+++ b/docker-compose-services/meilisearch/README.md
@@ -8,7 +8,7 @@ Copy [docker-compose.meilisearch.yaml](docker-compose.meilisearch.yaml) to your 
 
 ## Configuration
 
-From within the container, the meilisearch container is reached at hostname: ddev-<projectname>-meilisearch, port: 7700, so the server URL might be `http://ddev-<projectname>-meilisearch:7700`.
+From within the container, the meilisearch container is reached at hostname: ddev-\<projectname\>-meilisearch, port: 7700, so the server URL might be `http://ddev-<projectname>-meilisearch:7700`.
 
 ## Connection
 

--- a/docker-compose-services/meilisearch/README.md
+++ b/docker-compose-services/meilisearch/README.md
@@ -3,13 +3,15 @@
 [Meilisearch](https://www.meilisearch.com/) is an open source search-engine and can be used in ddev to handle searchindexes for the Drupal search_api.
 Using official meilisearch v0.20.0 container [meilisearch](https://hub.docker.com/r/getmeili/meilisearch).
 
+**Warning for Mac M1/arm64 users**: Because the old meilisearch v0.20.0 image does not provide arm64 images, this can't be used on mac M1 or other arm64 systems.
+
 ## Installation
 
 Copy [docker-compose.meilisearch.yaml](docker-compose.meilisearch.yaml) to your project's .ddev folder.
 
 ## Configuration
 
-From within the container, the meilisearch container is reached at hostname: ddev-\<projectname\>-meilisearch, port: 7700, so the server URL might be `http://ddev-<projectname>-meilisearch:7700`.
+From within the container, the meilisearch container is reached at hostname: `ddev-<projectname>-meilisearch`, port: 7700, so the in-container server URL might be `http://ddev-<projectname>-meilisearch:7700`.
 
 ## Connection
 
@@ -19,7 +21,7 @@ You can use `ddev logs -s meilisearch` to investigate what the meilissearch daem
 
 ## Additional Resources
 
-- https://www.drupal.org/project/search_api_meilisearch
-- https://docs.meilisearch.com/learn/getting_started/quick_start.html
+- [Drupal search_api_meilisearch module](https://www.drupal.org/project/search_api_meilisearch)
+- [Meiliseearch docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html)
 
 **Contributed by [@thilohille](https://github.com/thilohille)**

--- a/docker-compose-services/meilisearch/README.md
+++ b/docker-compose-services/meilisearch/README.md
@@ -1,5 +1,6 @@
 # Meilisearch
 
+[Meilisearch](https://www.meilisearch.com/) is an open source search-engine and can be used in ddev to handle searchindexes for the Drupal search_api.
 Using official meilisearch v0.20.0 container [meilisearch](https://hub.docker.com/r/getmeili/meilisearch).
 
 ## Installation
@@ -18,5 +19,7 @@ You can use `ddev logs -s meilisearch` to investigate what the meilissearch daem
 
 ## Additional Resources
 
-* https://www.drupal.org/project/search_api_meilisearch
-* https://docs.meilisearch.com/learn/getting_started/quick_start.html
+- https://www.drupal.org/project/search_api_meilisearch
+- https://docs.meilisearch.com/learn/getting_started/quick_start.html
+
+**Contributed by [@thilohille](https://github.com/thilohille)**

--- a/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
+++ b/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
@@ -1,0 +1,27 @@
+version: '0.36'
+services:
+  meilisearch:
+    container_name: ddev-${DDEV_SITENAME}-meilisearch
+    image: getmeili/meilisearch:v0.20.0
+    hostname: ${DDEV_SITENAME}-meilisearch
+    ports:
+      - 7700:7700
+    volumes:
+      - type: "volume"
+        source: meilisearch
+        target: "/data.ms"
+        volume:
+          nocopy: true
+      - type: "bind"
+        source: "."
+        target: "/mnt/ddev_config"
+      - ddev-global-cache:/mnt/ddev-global-cache
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+  web:
+    links:
+      - meilisearch:meilisearch
+
+volumes:
+  meilisearch:

--- a/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
+++ b/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
@@ -1,11 +1,14 @@
-version: '0.36'
+version: '3.6'
 services:
   meilisearch:
     container_name: ddev-${DDEV_SITENAME}-meilisearch
     image: getmeili/meilisearch:v0.20.0
     hostname: ${DDEV_SITENAME}-meilisearch
-    ports:
-      - 7700:7700
+    expose:
+      - "7700"
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=7700:7700
     volumes:
       - type: "volume"
         source: meilisearch


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
This receipe adds a meilisearch container to the project.
Meilisearch is an open source search-engine and can be used to handle searchindexes for the Drupal search_api.

## Manual Testing Instructions:
Follow the instructions from docker-compose-services/meilisearch/README.md.
Expected result:
* a working meilisearch instance is available in the project 
* the meilisearch backend is reachable at http://<projectname>.ddev.site:7700
