### PR TITLE
update elasticsearch to 7.16.2

### DIFF
--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ services:
   elasticsearch:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
-    image: elasticsearch:7.10.1
+    image: elasticsearch:7.16.2
     expose:
       - "9200"
       - "9300"


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:

The elasticsearch 7.10.1 is probably vulnerable to Log4Shell.

## How this PR Solves The Problem:

It updates elasticsearch to 7.16.2 where Log4Shell CVE is not detected.

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

Just try to run ddev with this yaml.

## Related Issue Link(s):

https://hub.docker.com/layers/elasticsearch/library/elasticsearch/7.16.2/images/sha256-3e82c0aefb87f2b716d0d09ffc252076b200a05eb1692c795dcb5c3057952477?context=explore
