### PR TITLE
Prepare "networks:" and "links:" for ddev v1.19

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -7,16 +7,15 @@ version: '3.6'
 services:
   chromedriver:
     image:  drupalci/webdriver-chromedriver:production
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-chromedriver
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
     external_links:
-      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
+      - ddev-router:${DDEV_HOSTNAME}
 
   web:
-    links:
-      - chromedriver
     environment:
       # *** One of these must be uncommented ***
       # In order for the system to work, one of these must be uncommented so

--- a/docker-compose-services/elastichq/docker-compose.elastichq.yaml
+++ b/docker-compose-services/elastichq/docker-compose.elastichq.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-elastichq
     hostname: ${DDEV_SITENAME}-elastichq
     image: elastichq/elasticsearch-hq
+    networks: [default, ddev_default]
     restart: always
     expose:
       - "5000"
@@ -17,6 +18,3 @@ services:
       - HQ_DEFAULT_URL=http://ddev-${DDEV_PROJECT}-elasticsearch:9200
     volumes:
       - ".:/mnt/ddev_config"
-  elasticsearch:
-    links:
-      - elastichq:elastichq

--- a/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
+++ b/docker-compose-services/elasticsearch/docker-compose.elasticsearch.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-elasticsearch
     hostname: ${DDEV_SITENAME}-elasticsearch
     image: elasticsearch:7.16.2
+    networks: [default, ddev_default]
     expose:
       - "9200"
       - "9300"
@@ -21,9 +22,6 @@ services:
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
       - ".:/mnt/ddev_config"
-  web:
-    links:
-      - elasticsearch:elasticsearch
 
 volumes:
   elasticsearch:

--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -5,6 +5,7 @@ services:
         image:  isholgueras/chrome-headless:latest
         restart: unless-stopped
         container_name: ddev-${DDEV_SITENAME}-chrome
+        networks: [default, ddev_default]
         labels:
             com.ddev.site-name: ${DDEV_SITENAME}
             com.ddev.approot: $DDEV_APPROOT

--- a/docker-compose-services/kibana/docker-compose.kibana.yaml
+++ b/docker-compose-services/kibana/docker-compose.kibana.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_PROJECT}-kibana
     hostname: ${DDEV_PROJECT}-kibana
     image: docker.elastic.co/kibana/kibana:7.10.1
+    networks: [default, ddev_default]
     restart: "no"
     expose:
       - '5601'

--- a/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
+++ b/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
@@ -3,6 +3,7 @@ services:
   meilisearch:
     container_name: ddev-${DDEV_SITENAME}-meilisearch
     image: getmeili/meilisearch:v0.20.0
+    networks: [default, ddev_default]
     hostname: ${DDEV_SITENAME}-meilisearch
     expose:
       - "7700"

--- a/docker-compose-services/mongodb/docker-compose.mongo.yaml
+++ b/docker-compose-services/mongodb/docker-compose.mongo.yaml
@@ -24,14 +24,12 @@ services:
   mongo-express:
     container_name: ddev-${DDEV_SITENAME}-mongo-express
     image: mongo-express:0.49
+    networks: [default, ddev_default]
     restart: "no"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: ${DDEV_APPROOT}
       com.ddev.platform: ddev
-
-    links:
-    - mongo:mongo
     expose:
     - "8081"
     environment:
@@ -39,10 +37,6 @@ services:
       ME_CONFIG_MONGODB_ADMINUSERNAME: db
       ME_CONFIG_MONGODB_ADMINPASSWORD: db
       HTTP_EXPOSE: "8081:8081"
-
-  web:
-    links:
-    - mongo:mongo
 
 volumes:
   mongo:

--- a/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
+++ b/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
@@ -7,6 +7,7 @@ services:
 #    image: devilbox/php-fpm:5.3-work
 #    image: devilbox/php-fpm:5.4-work
 #    image: devilbox/php-fpm:5.5-work
+    networks: [default, ddev_default]
 
     restart: "no"
     ports:
@@ -26,8 +27,6 @@ services:
       - IS_DDEV_PROJECT=true
 
   web:
-    links:
-    - php:php
     healthcheck:
       # Use "true" as the healthcheck to ignore its result
       test: ["CMD", "true"]

--- a/docker-compose-services/php8_1/docker-compose.php8_1.yaml
+++ b/docker-compose-services/php8_1/docker-compose.php8_1.yaml
@@ -3,6 +3,7 @@ version: '3.6'
 services:
   php:
     container_name: ddev-${DDEV_SITENAME}-php
+    networks: [default, ddev_default]
     restart: "no"
     # On Linux may need to to `export UID` in your environment
     # or add UID in project's .ddev/.env
@@ -11,8 +12,6 @@ services:
       context: './php-build'
       args:
         BASE_IMAGE: php:8.1.0alpha3-fpm-buster
-    links:
-      - db:db
     expose:
       - 9000
     labels:

--- a/docker-compose-services/portainer/docker-compose.portainer.yaml
+++ b/docker-compose-services/portainer/docker-compose.portainer.yaml
@@ -3,6 +3,7 @@ version: '3.6'
 services:
   portainer:
     image: portainer/portainer:latest
+    networks: [default, ddev_default]
     expose:
       - "9000"
     environment:
@@ -23,8 +24,3 @@ services:
       - SYS_ADMIN
 volumes:
   portainer_data:
-
-networks:
-  default:
-    external:
-      name: ddev_default

--- a/docker-compose-services/postgres/docker-compose.postgres.yaml
+++ b/docker-compose-services/postgres/docker-compose.postgres.yaml
@@ -3,6 +3,7 @@ services:
   postgres:
     container_name: ddev-${DDEV_SITENAME}-postgres
     image: postgres:13.4
+    networks: [default, ddev_default]
     ports:
       - 32784:5432
     environment:
@@ -23,9 +24,6 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT
-  web:
-    links:
-      - postgres:postgres
 
 volumes:
   postgres:

--- a/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
+++ b/docker-compose-services/rabbitmq/docker-compose.rabbitmq.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-rabbitmq
     hostname: ${DDEV_SITENAME}-rabbitmq
     image: "rabbitmq:3-management"
+    networks: [default, ddev_default]
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -18,8 +19,5 @@ services:
     volumes:
       - "./rabbitmq-build/enabled_plugins:/etc/rabbitmq/enabled_plugins"
       - ".:/mnt/ddev_config"
-  web:
-    links:
-      - rabbitmq:rabbitmq
 volumes:
   rabbitmq:

--- a/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
+++ b/docker-compose-services/redis-commander/docker-compose.redis-commander.yaml
@@ -4,6 +4,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-redis-commander
     hostname: ${DDEV_SITENAME}-redis-commander
     image: rediscommander/redis-commander
+    networks: [default, ddev_default]
     restart: always
     ports:
       - 1358
@@ -19,6 +20,3 @@ services:
       - PORT=1358
     volumes:
       - ".:/mnt/ddev_config"
-  redis:
-    links:
-      - redis-commander:redis-commander

--- a/docker-compose-services/redis/docker-compose.redis.yaml
+++ b/docker-compose-services/redis/docker-compose.redis.yaml
@@ -6,6 +6,7 @@ services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
     image: redis:4
+    networks: [default, ddev_default]
     ports:
       - 6379
     labels:
@@ -18,5 +19,3 @@ services:
   web:
     depends_on:
       - redis
-    links:
-      - redis:redis

--- a/docker-compose-services/solr-4/docker-compose.solr.yml
+++ b/docker-compose-services/solr-4/docker-compose.solr.yml
@@ -7,6 +7,7 @@ services:
     # Name of container using standard ddev convention.
     container_name: ddev-${DDEV_SITENAME}-solr
     image: geerlingguy/solr:4.10.4
+    networks: [default, ddev_default]
     restart: "always"
     # Solr is served from this port inside the container.
     ports:
@@ -39,12 +40,6 @@ services:
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
 
-  # This links the Solr service to the web service defined in the main
-  # docker-compose.yml, allowing applications running inside the web container to
-  # access the Solr service at http://solr:8983
-  web:
-    links:
-      - solr:solr
 volumes:
   # solr is a persistent Docker volume for solr data
   # The persistent volume should have the same name as the service so it can be deleted

--- a/docker-compose-services/solr-5/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-5/docker-compose.solr.yaml
@@ -32,6 +32,7 @@ services:
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
     image: solr:5
+    networks: [default, ddev_default]
     restart: "no"
     # Solr is served from this port inside the container.
     ports:
@@ -73,12 +74,6 @@ services:
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
 
-  # This links the Solr service to the web service defined in the main
-  # docker-compose.yml, allowing applications running inside the web container to
-  # access the Solr service at http://solr:8983
-  web:
-    links:
-      - solr:solr
 volumes:
   # solr_var and solr_opt are a persistent Docker volumes for solr data.
   # They are not automatically deleted, so you may need to delete them on your

--- a/docker-compose-services/solr-7/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-7/docker-compose.solr.yaml
@@ -32,6 +32,7 @@ services:
     # README: https://github.com/docker-solr/docker-solr/blob/master/README.md
     # It's almost impossible to work with it if you don't read the docs there
     image: solr:7
+    networks: [default, ddev_default]
     restart: "no"
     # Solr is served from this port inside the container.
     ports:
@@ -73,12 +74,6 @@ services:
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
 
-  # This links the Solr service to the web service defined in the main
-  # docker-compose.yml, allowing applications running inside the web container to
-  # access the Solr service at http://solr:8983
-  web:
-    links:
-      - solr:solr
 volumes:
   # solr is a persistent Docker volume for solr data
   # The persistent volume should have the same name as the service so it can be deleted

--- a/docker-compose-services/solr/docker-compose.solr-standalone.yaml
+++ b/docker-compose-services/solr/docker-compose.solr-standalone.yaml
@@ -26,6 +26,7 @@ version: '3.6'
 services:
   solr:
     image: solr:8
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-solr
     expose:
       - 8983
@@ -51,6 +52,7 @@ services:
 
   zoo:
     image: bitnami/zookeeper:3.7
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-zoo
     hostname: ddev-${DDEV_SITENAME}-zoo
     expose:
@@ -68,13 +70,6 @@ services:
     volumes:
       - .:/mnt/ddev_config
       - zoo:/bitnami/zookeeper
-
-  # This links the Solr service to the web service defined in the main
-  # docker-compose.yml, allowing applications running inside the web container to
-  # access the Solr service at http://solr:8983
-  web:
-    links:
-      - solr:solr
 
 volumes:
   solr:

--- a/docker-compose-services/solr/docker-compose.solr.yaml
+++ b/docker-compose-services/solr/docker-compose.solr.yaml
@@ -20,6 +20,7 @@ version: '3.6'
 services:
   solr1:
     image: solr:8
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-solr1
     expose:
       - 8983
@@ -45,6 +46,7 @@ services:
 
   solr2:
     image: solr:8
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-solr2
     expose:
       - 8984
@@ -68,6 +70,7 @@ services:
 
   solr3:
     image: solr:8
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-solr3
     expose:
       - 8985
@@ -91,6 +94,7 @@ services:
 
   zoo:
     image: bitnami/zookeeper:3.7
+    networks: [default, ddev_default]
     container_name: ddev-${DDEV_SITENAME}-zoo
     hostname: ddev-${DDEV_SITENAME}-zoo
     expose:

--- a/docker-compose-services/typo3-solr/docker-compose.solr.yaml
+++ b/docker-compose-services/typo3-solr/docker-compose.solr.yaml
@@ -3,6 +3,7 @@ version: '3.6'
 services:
   solr:
     container_name: ddev-${DDEV_SITENAME}-solr
+    networks: [default, ddev_default]
     image: typo3solr/ext-solr:10.0.1
     restart: "no"
     expose:
@@ -19,9 +20,6 @@ services:
       # If you uncomment it and want to flush your data you have to `ddev stop` and then
       # `docker volume rm ddev-<projectname>_solrdata` to destroy it.
 #      - solr:/var/solr
-  web:
-    links:
-      - solr
 
 volumes:
   # solr is a persistent Docker volume for this project's solr data

--- a/docker-compose-services/varnish/docker-compose.varnish.yml
+++ b/docker-compose-services/varnish/docker-compose.varnish.yml
@@ -9,6 +9,7 @@ services:
     container_name: ddev-${DDEV_SITENAME}-varnish
     # Use "varnish:latest" to get the latest stable image.
     image: varnish:6.4
+    networks: [default, ddev_default]
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
@@ -28,8 +29,6 @@ services:
       # your default.vcl should be.
       - "./varnish:/etc/varnish"
       - ".:/mnt/ddev_config"
-    links:
-      - web:web
   # This is the second half of the trick that puts varnish "in front of" the web
   # container, just by switching the names.
   web:

--- a/docker-compose-snippets/project-communication/docker-compose.project2.yaml
+++ b/docker-compose-snippets/project-communication/docker-compose.project2.yaml
@@ -3,3 +3,8 @@ services:
   web:
     external_links:
     - "ddev-router:project2.ddev.site"
+
+  # if you want a custom service to be reachable cross-project, add it 
+  # to the inter-project network "ddev":
+  my_service:
+    networks: [default, ddev_default]


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
For ddev v1.19 we'll have to update services that need to be reachable or reach the router or inter-project services.

## How this PR Solves The Problem:
This removes superfluous `links:` and adds `networks: [ default, ddev ]` were inter-project communication is necessary.

## Related Issue Link(s):
https://github.com/drud/ddev/pull/3403