### PR TITLE
Fix documentation for getting old PHP versions working

### DIFF
--- a/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
+++ b/docker-compose-services/old_php/.ddev/docker-compose.php.yaml
@@ -3,10 +3,10 @@ version: '3.6'
 services:
   php:
     container_name: ddev-${DDEV_SITENAME}-php
-    image: devilbox/php-fpm-5.2
-#    image: devilbox/php-fpm-5.3
-#    image: devilbox/php-fpm:5.4-prod
-#    image: devilbox/php-fpm:5.5-prod
+    image: devilbox/php-fpm:5.2-work
+#    image: devilbox/php-fpm:5.3-work
+#    image: devilbox/php-fpm:5.4-work
+#    image: devilbox/php-fpm:5.5-work
 
     restart: "no"
     ports:
@@ -21,6 +21,9 @@ services:
       consistency: cached
     - ".:/mnt/ddev_config:ro"
     - ddev-global-cache:/mnt/ddev-global-cache
+    environment:
+      - DDEV_PHP_VERSION
+      - IS_DDEV_PROJECT=true
 
   web:
     links:

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -1,14 +1,14 @@
-# Using Old PHP Versions (pre-php5.6)
+# Using old PHP versions (pre-php5.6)
 
 It's not uncommon to need to be able to run a site that has been neglected for years or decades, often for upgrading, migrating, copying, or archiving purposes. But normally there are just too many errors and problems with these very old sites to get them to run with more recent PHP versions. And the oldest PHP version that ddev directly supports is PHP 5.6.
 
-However, there are images of older PHP versions on hub.docker.com and we can use them as third-party services to get the behavior we need, which is usually just being able to *look* at a site.
+However, there are images of older PHP versions on hub.docker.com, and we can use them as third-party services to get the behavior we need, which is usually just being able to *look* at a site.
 
 This recipe was explicitly tested on Drupal 4.7 and 5.x, both from the 2008-2010 timeframe. 5.x installation succeeded with this configuration and PHP 5.3. Drupal 4.7 installation (very manual) succeeeded with PHP 5.2. Another approach which I used initially is to build the site or recover it on an Ubuntu 12.04 VM.
 
 ## Architecture
 
-The normal DDEV-Local approach is to run both nginx/apache and php-fpm in the same container. However, it doesn't have to be that way. Here we're using *apache* int he regular ddev-webserver, but we've set the apache config to proxy to a different container, a php container running one of the Devilbox php images.
+The normal ddev approach is to run both Nginx/Apache and php-fpm in the same container. However, it doesn't have to be that way. Here we're using *Apache* in the regular ddev-webserver, but we've set the Apache config to proxy to a different container, a PHP container running one of the Devilbox PHP images.
 
 This means that the `php_version` you have set in your .ddev/config.yaml is irrelevant; the actual PHP version is the one in the Devilbox container.
 
@@ -20,21 +20,22 @@ If you're just kicking the tires, you can use a Drupal 4.7 version with `git clo
 
 ## ddev config
 
-* `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=5.5` sets up your project
+* `ddev config --project-type=php --webserver-type=apache-fpm --mariadb-version=5.5` sets up your project.
+
+Apache is required for the Devilbox PHP container to be used. The project type and MariaDB parameters are only needed if your project requires them.
 
 If your docroot is not the default, make sure to set it correctly in the .ddev/config.yaml.
-
-Using Apache is more likely to be compatible with older projects, as is the use of older MariaDB. And we use project type 'php' so that ddev is not tempted to update settings files.
 
 ## Copy the files from [.ddev](.ddev) into your project's .ddev
 
 For example `cp -r .ddev/* /path/to/your/repo/.ddev`
 
-This includes:
-
-* [apache/apache-site.conf](.ddev/apache/apache-site.conf), a generic apache configuration that does point to the external php container for php execution.
-* [mysql/noutf8.cnf](.ddev/mysql/noutf8.cnf), turning off UTF8 in MariaDB. utf8mb4, required for most current sites, makes indexes too long on some older sites.
+### Required
+* [apache/apache-site.conf](.ddev/apache/apache-site.conf), a generic apache configuration that points to the external PHP container for PHP execution.
 * [docker-compose.php.yaml](.ddev/docker-compose.php.yaml) adds the service itself.
+
+### Optional
+* [mysql/noutf8.cnf](.ddev/mysql/noutf8.cnf), turning off UTF8 in MariaDB. utf8mb4, required for most current sites, makes indexes too long on some older sites.
 
 ## Start the project with `ddev start`
 
@@ -48,14 +49,14 @@ If older databases have `TYPE=MyISAM` in the table creation stanzas, that will n
 
 ## Configure the database settings for your project
 
-ddev is taking no responsiblity for your settings files because you have `type: php`, so you'll need to configure your settings files. For example, on a Drupal 4.7 site, you'll need to add `$db_url = 'mysql://db:db@db/db';` to the sites/default/settings.php file. Don't forget that the *hostname* is 'db', not 'localhost' as often defaulted on many installers. (User/password/database are also 'db'.)
+ddev takes no responsiblity for your settings files if you have `type: php`, so you'll need to configure your settings files. For example, on a Drupal 4.7 site, you'll need to add `$db_url = 'mysql://db:db@db/db';` to the sites/default/settings.php file. Don't forget that the *hostname* is 'db', not 'localhost' as often defaulted on many installers. (User/password/database are also 'db'.)
 
 Now, if you're paranoid, do a `ddev restart` (probably unnecessary) and begin to debug the problems you've uncovered.
 
-The site you've set up can probably be used as a migration source, can be archived, converted to html with a sitesucker, etc.
+The site you've set up can probably be used as a migration source, can be archived, converted to HTML with a sitesucker, etc.
 
 ## Configure PHP settings
-You cannot set PHP settings in .htaccess when running php-fpm. But PHP will load settings from .user.ini. This is important for enabling Xdebug, because the .ddev/php/xdebug.ini that normally controls Xdebug settings is not used by old_php.
+You cannot set PHP settings in .htaccess unless PHP is running as an Apache module. When not run running as an Apache module, PHP loads settings from [.user.ini](https://www.php.net/manual/en/configuration.file.per-user.php). This is important for enabling Xdebug, because the .ddev/php/xdebug.ini file that normally controls Xdebug settings is not used by the Devilbox PHP container. See [example.user.ini](example.user.ini).
 
 ## Options
 
@@ -67,4 +68,4 @@ You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev
 * You definitely may have to do more than listed here to get your particular site going.
 * I haven't experimented with getting PHP4 to work. Please provide a PR to this recipe if you get it to work.
 
-**Originally by [@rfay](https://github.com/rfay)**
+**Contributed by [@rfay](https://github.com/rfay) and [@darrenoh](https://github.com/darrenoh)**

--- a/docker-compose-services/old_php/README.md
+++ b/docker-compose-services/old_php/README.md
@@ -54,6 +54,9 @@ Now, if you're paranoid, do a `ddev restart` (probably unnecessary) and begin to
 
 The site you've set up can probably be used as a migration source, can be archived, converted to html with a sitesucker, etc.
 
+## Configure PHP settings
+You cannot set PHP settings in .htaccess when running php-fpm. But PHP will load settings from .user.ini. This is important for enabling Xdebug, because the .ddev/php/xdebug.ini that normally controls Xdebug settings is not used by old_php.
+
 ## Options
 
 You may need another version of PHP. As noted in [docker-compose.php.yaml](.ddev/docker-compose.php.yaml), you can easily use 5.3, 5.4, or 5.5.

--- a/docker-compose-services/old_php/example.user.ini
+++ b/docker-compose-services/old_php/example.user.ini
@@ -1,0 +1,2 @@
+xdebug.remote_enable = on
+xdebug.remote_host = host.docker.internal


### PR DESCRIPTION
I had to do a little more than the README said to get Drupal working with an old version of PHP on ddev.