### PR TITLE
Add drupal pre-commit phpcs recipe running inside DDEV

### DIFF
--- a/recipes/git-hooks/pre-commit-drupal-phpcs/README.md
+++ b/recipes/git-hooks/pre-commit-drupal-phpcs/README.md
@@ -1,0 +1,19 @@
+# Drupal pre-commit PHPCS
+
+Runs PHPCS on the files to be commited from **inside** DDEV, regardless if
+you are committing from your host machine or from inside the container.
+
+## Installation
+
+Copy `pre-commit` and `pre-commit.php` under `PROJECT_ROOT/scripts/git/`
+and then:
+```
+chmod +x scripts/git/pre-commit
+cd .git/hooks && ln -s ../../scripts/git/pre-commit
+```
+
+### Advanced installation
+
+Paste the files wherever you want, but change the paths on lines 5 and 7
+in `pre-commit` file
+Don't forget to make the hook executable!

--- a/recipes/git-hooks/pre-commit-drupal-phpcs/pre-commit
+++ b/recipes/git-hooks/pre-commit-drupal-phpcs/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Run pre-commit check PHP script inside ddev when commiting from host.
+if [ "$IS_DDEV_PROJECT" != true ]; then
+  ddev exec /usr/bin/php scripts/git/pre-commit.php
+else
+  /usr/bin/php scripts/git/pre-commit.php
+fi

--- a/recipes/git-hooks/pre-commit-drupal-phpcs/pre-commit.php
+++ b/recipes/git-hooks/pre-commit-drupal-phpcs/pre-commit.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * @file
+ * A Git pre-commit hook script to check files for PHP syntax errors and Drupal
+ * coding standards violations. Requires phpcs and Coder Sniffer:
+ *
+ * @see https://drupal.org/node/1419988
+ *
+ * Heavily copied from https://www.drupal.org/project/dcq
+ * and modified for Drupal 8+ and for running **inside** DDEV.
+ *
+ * Ignores all files under config/sync
+ */
+
+const CONFIG_ROOT = 'config/sync';
+
+$return_back = '../../';
+// Building an array of ignored files and folders.
+$file_path = __DIR__ . '/' . $return_back . '.phpcs_ignore';
+$ignore = [];
+$ignore[] = CONFIG_ROOT;
+if (file_exists($file_path)) {
+  $file = fopen($file_path, "r");
+  if ($file) {
+    while (!feof($file)) {
+      $ignore[] = fgets($file);
+    }
+  }
+}
+
+// Extensions of files to test.
+$file_exts = array(
+  'php',
+  'module',
+  'inc',
+  'install',
+  'profile',
+  'test',
+  'theme',
+  'txt',
+  'info',
+  'md',
+  'yml',
+);
+
+$exit_code = 0;
+$files = array();
+$return = 0;
+
+// Determine whether this is the first commit or not. If it is, set $against to
+// the hash of a magical, empty commit to compare to.
+exec('git rev-parse --verify HEAD 2> /dev/null', $files, $return);
+$against = ($return == 0) ? 'HEAD' : '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+// Identify changed files.
+exec("git diff-index --cached --name-only $against", $files);
+
+print "\nPrecommit PHPCS\n\n";
+
+// The number of ignored items.
+$ignored_items_count = count($ignore);
+echo "\033[0;31mYou have $ignored_items_count item(s) in your ignore list!\n\033[0m";
+
+foreach ($files as $file) {
+
+  if (file_exists($file) && !is_dir($file)) {
+
+    // Check files to ignore.
+    if ($ignored_items_count > 0) {
+      foreach ($ignore as $key => $value) {
+        if (substr($file, 0, strlen(trim($value))) == trim($value) && trim($value) != '') {
+          echo "\033[0;31mIgnored in .phpcs_ignore file: $file\n\033[0m";
+          continue 2;
+        }
+      }
+    }
+
+    echo "\033[0;32mChecking file {$file}\033[0m\n\n";
+
+    $ext = pathinfo($file, PATHINFO_EXTENSION);
+
+    if (!in_array($ext, $file_exts)) {
+      continue;
+    }
+
+    $phpcs_output = array();
+
+    $file = escapeshellarg($file);
+    // Add extra path to get warranty for run drush.
+    $dir = str_replace('\'', '', dirname($file));
+    $extra = '';
+    if ($dir !== '.') {
+      $extra = $dir . '/';
+    }
+
+    // Perform PHP syntax check (lint).
+    $return = 0;
+    $lint_cmd = "php -l {$file}";
+    $lint_output = array();
+    exec($lint_cmd, $lint_output, $return);
+    if ($return !== 0) {
+      // Format error messages and set exit code.
+      $exit_code = 1;
+    }
+
+    // Perform phpcs test.
+    $return = 0;
+    $phpcs_cmd = 'cd /var/www/html && phpcs --standard=Drupal --extensions=php,module,inc,install,test,profile,theme ' . $file;
+    exec($phpcs_cmd, $phpcs_output, $return);
+    if ($return !== 0) {
+      // Format error messages and set exit code.
+      echo implode("\n", $phpcs_output), "\n";
+      $exit_code = 1;
+    }
+  }
+}
+
+exit($exit_code);


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## What is new:
Provide a git-hook recipe that executes PHPCS **from inside DDEV** during `git commit`.

This allows for the host machine to not have PHP and/or PHPCS installed at all, everything is happening inside the container, although the actual commit can happen either inside or outside of the container.

## How this PR Solves The Problem:
Provides the files and documentation needed.

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->
Follow the instruction in the README, stage a file that would fail in PHPCS and try to commit either from the host machine or from inside the web container in DDEV.

Sample photo (php errors are intentional):
![image](https://user-images.githubusercontent.com/520237/152147054-37226179-6ecf-4b89-b9cd-5d337b6df936.png)


## Related Issue Link(s):
https://github.com/drud/ddev/issues/3518 talks about the DDEV verbose line (last line in the above screenshot)
