### PR TITLE
📓 connecting from a Windows-domain account [skip_ci]

### DIFF
--- a/recipes/sshd/README.md
+++ b/recipes/sshd/README.md
@@ -14,7 +14,7 @@ Although most people do fine with `ddev ssh` and `ddev exec`, they don't actuall
 
 (The StrictHostKeyChecking=no is required because every time you restart the container it comes up with a new "host" identity.)
 
-* Note: If your are running DDEV from a domain connected Windows PC, you may need to specify a username.
+* Note: If you are running DDEV from a domain connected Windows PC, you may need to specify a username.
 
 1. First, check if your account is tied to a domain. From a command prompt, type `whoami`
 

--- a/recipes/sshd/README.md
+++ b/recipes/sshd/README.md
@@ -3,7 +3,7 @@
 Although most people do fine with `ddev ssh` and `ddev exec`, they don't actually use ssh, but are wrappers on `docker exec`. In the vast majority of cases, you don't need anything like this, but if you have an application that needs to *actually* use the real ssh protocols to access the web container, this recipe is for you.
 
 1. Copy [config.sshd.yaml](config.sshd.yaml) and [docker-compose.sshd.yaml](docker-compose.sshd.yaml) into your project's .ddev folder. (Note that you can also incorporate the contents of config.ssshd.yaml into your config.yaml.)
-2. Authorize your ssh client to access the web container's ssh server by adding a global `~/.ddev/homeadditions/.ssh/authorized_keys`, which will be copied into the ~/.ssh directory in the web container. The easiest way to do this, assuming your ssh pubkey is ~/.ssh/id_rsa.pub, is 
+2. Authorize your ssh client to access the web container's ssh server by adding a global `~/.ddev/homeadditions/.ssh/authorized_keys`, which will be copied into the ~/.ssh directory in the web container. The easiest way to do this, assuming your ssh pubkey is ~/.ssh/id_rsa.pub, is
     ```
     mkdir -p ~/.ddev/homeadditions/.ssh
     cp ~/.ssh/id_rsa.pub ~/.ddev/homeadditions/.ssh/authorized_keys
@@ -13,3 +13,20 @@ Although most people do fine with `ddev ssh` and `ddev exec`, they don't actuall
 4. Access the web container with `ssh -p 2222 -o StrictHostKeyChecking=no localhost`
 
 (The StrictHostKeyChecking=no is required because every time you restart the container it comes up with a new "host" identity.)
+
+* Note: If your are running DDEV from a domain connected Windows PC, you may need to specify a username.
+
+1. First, check if your account is tied to a domain. From a command prompt, type `whoami`
+
+```shell
+> whoami
+work\user13
+```
+
+The above shows the current user `user13` is connected to the `work` domain.
+
+2. If your account is tied to a domain, as above, you need to specify a username when connecting:  `<username>@localhost`, replace username with your user (Eg. user13);
+
+```shell
+ssh -p 2222 -o StrictHostKeyChecking=no <username>@localhost
+```


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
Recently came across an issue when attempting to connect to DDEV via SSH from a domain-authenticated account on Window 10.

This a typical setup for Windows PCs in a work enviroment (Windows server).

## How this PR Solves The Problem:
This PR outlines

- how to check if you are on a domain-authenticated account
- correct ssh command required if true


## Related Issue Link(s):
#198
