### PR TITLE
Improve tinker command

### DIFF
--- a/custom-commands/tinker/README.md
+++ b/custom-commands/tinker/README.md
@@ -7,7 +7,7 @@
 
 Both Laravel and Drupal have an interactive debugger & REPL environment for tinkering in PHP. You can test various php statements, resolve services or even query the database! Both environment's are customized versions of the excellent [PsySh](https://psysh.org/).
 
-- Laravel: [`php artisan tinker`](https://laravel.com/docs/8.x/artisan#tinker)
+- Laravel: [`php artisan tinker`](https://laravel.com/docs/artisan#tinker)
 
 - Drupal via a Drush: [`drush php`](https://www.drush.org/latest/commands/php_cli/)
 

--- a/custom-commands/tinker/README.md
+++ b/custom-commands/tinker/README.md
@@ -35,31 +35,31 @@ ddev tinker
 
 ### Arguments
 
-Arguments are currently supported (with caveats ) in *Laravel projects only*.
+- Tinker can accept simple arguments.
 
 ```shell
 $ ddev tinker 6+8
 14
+```
 
-$ ddev tinker "'User::first()'"
+- More complex arguments should be wrapped with <kbd>'</kbd>.
+
+```shell
+$ ddev tinker 'User::first()'
 [!] Aliasing 'User' to 'App\Models\User' for this Tinker session.
 App\Models\User^ {#4400
 ...
+
+$ ddev tinker 'node_access_rebuild()'
+ [notice] Message: Content permissions have been rebuilt.
+
+$ ddev tinker '$node = \Drupal\node\Entity\Node::load(1); print $node->getTitle();'
+Who Doesn’t Like a Good Waterfall?
 ```
 
-There is [known issue](https://github.com/drud/ddev/issues/2547) when arguments contain:
-
-- quotes (`"`, `'`)
-- or brackets (`(` , `)`)
-
-There are 2 known workaround:
-
-- escape the character:
-  - `ddev tinker "User::find(1)"` => `ddev tinker "User::find\(1\)"`
-- double-wrap; use a different matching pair of quotes:
-  - `ddev tinker "User::find(1)"` => `ddev tinker '"User::find(1)"'`
-  - `ddev tinker "User::find(1)"` => `ddev tinker "'User::find(1)'"`
-
 While this might be helpful for a quick one-off command, it's recommend to run `ddev tinker` for tinkering to avoid any Docker connection delays between multiple commands.
+
+- Wrapping may also work with <kbd>"</kbd>, depending on the command used. For more consistent results between frameworks and host OS, it is recommended to use <kbd>'</kbd>.
+- See https://github.com/drud/ddev/issues/2547
 
 **Contributed by [@tyler36](https://github.com/tyler36)**

--- a/custom-commands/tinker/web/tinker
+++ b/custom-commands/tinker/web/tinker
@@ -3,7 +3,7 @@
 ## Description: Run project PHP REPL. Arguments are accepted in Laravel projects (with caveats)
 ## Usage: tinker
 ## Example: "ddev tinker"
-## ProjectTypes: laravel,drupal7,drupal8,drupal9,drupal10
+## ProjectTypes: laravel,drupal7,drupal8,drupal9
 
 if [ "${DDEV_PROJECT_TYPE}" == "laravel" ]; then
   if [ -z "$1" ]
@@ -22,6 +22,7 @@ if [ "${DDEV_PROJECT_TYPE}" == "laravel" ]; then
   exit 0
 fi
 
+# If this it hit, it's must be a Drupal project type.
 
 if ! command -v drush >/dev/null; then
   echo "drush is not available. You may need to 'ddev composer require drush/drush'"

--- a/custom-commands/tinker/web/tinker
+++ b/custom-commands/tinker/web/tinker
@@ -3,7 +3,7 @@
 ## Description: Run project PHP REPL. Arguments are accepted in Laravel projects (with caveats)
 ## Usage: tinker
 ## Example: "ddev tinker"
-## ProjectTypes: laravel,drupal7,drupal8,drupal9
+## ProjectTypes: laravel,drupal7,drupal8,drupal9,drupal10
 
 if [ "${DDEV_PROJECT_TYPE}" == "laravel" ]; then
   if [ -z "$1" ]

--- a/custom-commands/tinker/web/tinker
+++ b/custom-commands/tinker/web/tinker
@@ -3,7 +3,7 @@
 ## Description: Run project PHP REPL. Arguments are accepted in Laravel projects (with caveats)
 ## Usage: tinker
 ## Example: "ddev tinker"
-## ProjectTypes: laravel,drupal7,drupal8,drupal9
+## ProjectTypes: laravel,drupal7,drupal8,drupal9,drupal10
 
 if [ "${DDEV_PROJECT_TYPE}" == "laravel" ]; then
   if [ -z "$1" ]
@@ -29,4 +29,9 @@ if ! command -v drush >/dev/null; then
   exit 1
 fi
 
-drush php
+if [ -z "$1" ]
+  then
+      drush php
+  else
+      drush php:eval "$1"
+fi

--- a/custom-commands/tinker/web/tinker
+++ b/custom-commands/tinker/web/tinker
@@ -3,19 +3,16 @@
 ## Description: Run project PHP REPL. Arguments are accepted in Laravel projects (with caveats)
 ## Usage: tinker
 ## Example: "ddev tinker"
+## Example: "ddev tinker 'User::first()->email'"
+## Example: "dev tinker '$node = \Drupal\node\Entity\Node::load(1); print $node->getTitle();'"
 ## ProjectTypes: laravel,drupal7,drupal8,drupal9,drupal10
+## ExecRaw: true
 
 if [ "${DDEV_PROJECT_TYPE}" == "laravel" ]; then
   if [ -z "$1" ]
       then
           php artisan tinker
       else
-          # There is an known issue if the arguments contain quotes (`"`, `'`) or brackets (`(` , `)`)
-          # There are 2 known workaround: escape the characters or double-wrap the quotes
-          # - ddev tinker "User::find(1)" => ddev tinker "User::find\(1\)"
-          # - ddev tinker "User::find(1)" => ddev tinker '"User::find(1)"'
-          # - ddev tinker "User::find(1)" => ddev tinker "'User::find(1)'"
-          # See https://github.com/drud/ddev/issues/2547
           php artisan tinker --execute="dd($1);"
   fi
 


### PR DESCRIPTION
## How this PR Solves The Problem:
- Add `Drupal10` support
- Allow Drush to accept arguments

Currently, there are issues with quotes and working with bash.  There are some documented workaround in this command but they are not idea.

https://github.com/drud/ddev/pull/3603 opens up the possibility of support so this is kinda premptive and offers another real-world case for testing and support.


Ideally, we should be able to run the examples on the [Drush php:eval](https://www.drush.org/latest/commands/php_eval/) page:

```shell
ddev tinker "$node = \Drupal\node\Entity\Node::load(1); print $node->getTitle();"
ddev tinker "node_access_rebuild()"
```

## Manual Testing Instructions:

```shell
gitpod /workspace/d9simple (main) $ ddev tinker "dump(4+4)"
^ 8
```

## Related Issue Link(s):

https://github.com/drud/ddev/pull/3603
