### PR TITLE
[WIP] Add 'refresh' script for (re)initializing/resetting Drupal environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/cust
 * [Stop all running projects except the current](custom-commands/stop-other)
 * [Dynamically enable / disable a service](custom-commands/dynamic-service)
 * [Automatically open browser and login to Drupal](custom-commands/drupal-login)
+* [Refresh your local Drupal environment in one command](custom-commands/drupal-refresh)
 
 ## Additional services added via docker-compose.\<service\>.yaml
 

--- a/custom-commands/drupal-refresh/README.md
+++ b/custom-commands/drupal-refresh/README.md
@@ -1,0 +1,52 @@
+# Refresh your local Drupal environment in one command
+
+This command refreshes your local Drupal environment, including steps to:
+- fetch the latest code
+- download and import a database
+- compile front-end assets
+- composer install
+- execute Drupal database updates
+- rebuild caches
+- and other stuff
+
+It currently relies on [Drainpipe](https://github.com/Lullabot/drainpipe/) for
+some functionality, but you may replace the `task` commands with your own steps.
+E.g., 
+[these steps](https://architecture.lullabot.com/adr/20210924-drupal-build-steps)
+for building Drupal.
+
+You may pass a branch name, and `refresh` will switch to that branch before
+running the steps. This is useful e.g. to give other developers a one-line
+command to set up your feature in their local environment for testing and code
+review.
+
+To use, place the `refresh` script in your project's `.ddev/commands/host`
+folder.
+
+If you don't need `refresh` to run _all_ the steps, you can pass various flags
+to turn behavior on and off. Detailed usage:
+
+```
+$ ddev refresh -h
+
+Refreshes the local development environment.
+
+Usage:
+ddev refresh [branch] [flags]
+
+Examples:
+"ddev refresh some-branch --no-restart --import-db"
+
+Flags:
+-e, --existing-sql   Import the existing/previously-downloaded database dump rather than downloading a new one.
+-h, --help           help for refresh
+-i, --import-db      Import a Drupal database dump (downloads a fresh copy unless the "--existing-sql" flag is given).
+-A, --no-assets      Don't compile front-end assets (JS, CSS, etc).
+-C, --no-composer    Don't run "composer install".
+-G, --no-git-pull    Don't update the git branch.
+-L, --no-login       Don't open a browser in a one-time login URL.
+-R, --no-restart     Don't restart ddev, e.g., because you know there have been no ddev configuration changes.
+-U, --no-update      Don't run Drupal database updates, import configuration, or clear caches, etc.
+-v, --verbose        Show more command output.
+-y, --yes            Automaticallly answer "yes" to all confirmation prompts.
+```

--- a/custom-commands/drupal-refresh/README.md
+++ b/custom-commands/drupal-refresh/README.md
@@ -9,12 +9,6 @@ This command refreshes your local Drupal environment, including steps to:
 - rebuild caches
 - and other stuff
 
-It currently relies on [Drainpipe](https://github.com/Lullabot/drainpipe/) for
-some functionality, but you may replace the `task` commands with your own steps.
-E.g.,
-[these steps](https://architecture.lullabot.com/adr/20210924-drupal-build-steps)
-for building Drupal.
-
 You may pass a branch name, and `refresh` will switch to that branch before
 running the steps. This is useful e.g. to give other developers a one-line
 command to set up your feature in their local environment for testing and code

--- a/custom-commands/drupal-refresh/README.md
+++ b/custom-commands/drupal-refresh/README.md
@@ -11,7 +11,7 @@ This command refreshes your local Drupal environment, including steps to:
 
 It currently relies on [Drainpipe](https://github.com/Lullabot/drainpipe/) for
 some functionality, but you may replace the `task` commands with your own steps.
-E.g., 
+E.g.,
 [these steps](https://architecture.lullabot.com/adr/20210924-drupal-build-steps)
 for building Drupal.
 
@@ -50,3 +50,5 @@ Flags:
 -v, --verbose        Show more command output.
 -y, --yes            Automaticallly answer "yes" to all confirmation prompts.
 ```
+
+**Contributed by [Hawkeye Tenderwolf](https://github.com/hawkeyetwolf)**

--- a/custom-commands/drupal-refresh/README.md
+++ b/custom-commands/drupal-refresh/README.md
@@ -9,13 +9,13 @@ This command refreshes your local Drupal environment, including steps to:
 - rebuild caches
 - and other stuff
 
+To install this ddev custom command, place the `refresh` script in your
+project's `.ddev/commands/host/` folder.
+
 You may pass a branch name, and `refresh` will switch to that branch before
 running the steps. This is useful e.g. to give other developers a one-line
 command to set up your feature in their local environment for testing and code
 review.
-
-To use, place the `refresh` script in your project's `.ddev/commands/host/`
-folder.
 
 If you don't need `refresh` to run _all_ the steps, you can pass various flags
 to turn behavior on and off. Detailed usage:

--- a/custom-commands/drupal-refresh/README.md
+++ b/custom-commands/drupal-refresh/README.md
@@ -14,7 +14,7 @@ running the steps. This is useful e.g. to give other developers a one-line
 command to set up your feature in their local environment for testing and code
 review.
 
-To use, place the `refresh` script in your project's `.ddev/commands/host`
+To use, place the `refresh` script in your project's `.ddev/commands/host/`
 folder.
 
 If you don't need `refresh` to run _all_ the steps, you can pass various flags

--- a/custom-commands/drupal-refresh/host/refresh
+++ b/custom-commands/drupal-refresh/host/refresh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+## Description: Refreshes the local development environment.
+## Usage: refresh [branch]
+## Example: "ddev refresh some-branch --no-restart --import-db"
+## Flags: [{"Name":"no-assets","Shorthand":"A","Usage":"Don't compile front-end assets (JS, CSS, etc)."},{"Name":"no-composer","Shorthand":"C","Usage":"Don't run \"composer install\"."},{"Name":"no-git-pull","Shorthand":"G","Usage":"Don't update the git branch."},{"Name":"no-restart","Shorthand":"R","Usage":"Don't restart ddev, e.g., because you know there have been no ddev configuration changes."},{"Name":"no-update","Shorthand":"U","Usage":"Don't run Drupal database updates, import configuration, or clear caches, etc."},{"Name":"no-login","Shorthand":"L","Usage":"Don't open a browser in a one-time login URL."},{"Name":"import-db","Shorthand":"i","Usage":"Import a Drupal database dump (downloads a fresh copy unless the \"--existing-sql\" flag is given)."},{"Name":"existing-sql","Shorthand":"e","Usage":"Import the existing/previously-downloaded database dump rather than downloading a new one."},{"Name":"yes","Shorthand":"y","Usage":"Automaticallly answer \"yes\" to all confirmation prompts."},{"Name":"verbose","Shorthand":"v","Usage":"Show more command output."}]
+
+# Initialize options variables.
+skip_prompts=0
+can_import_db=0
+existing_sql=0
+no_git_pull=0
+no_restart=0
+no_composer=0
+no_assets=0
+no_update=0
+no_login=0
+
+# Parse command flags and arguments. Adapted from
+# https://stackoverflow.com/a/62616466
+EOL=$(echo '\01\03\03\07')
+usage_error () { printf >&2 "\n[error] $@\n" ; exit 2 ; }
+if [ "$#" -gt 0 ] ; then
+  set -- "$@" "$EOL"
+  while [ "$1" != "$EOL" ] ; do
+    opt="$1"
+    shift
+    case "$opt" in
+
+      ######################################
+      ### BEGIN: PROCESS COMMAND OPTIONS ###
+      ######################################
+
+      # Standard flags. Note that DDEV provides "--help" (usage) automatically.
+      # Support multiple "v" flags.
+      -v | --verbose ) [ $verbose ] && verbose="${verbose}v" || verbose="-v" ;;
+      -y | --yes     ) skip_prompts=1 ;;
+
+      # Flags to enable steps that are disabled by default.
+      -i | --import-db    ) can_import_db=1 ;;
+      -e | --existing-sql ) existing_sql=1 ;;
+
+      # Flags to skip steps that are enabled by default.
+      -G | --no-git-pull ) no_git_pull=1 ;;
+      -R | --no-restart  ) no_restart=1 ;;
+      -C | --no-composer ) no_composer=1 ;;
+      -A | --no-assets   ) no_assets=1 ;;
+      -U | --no-update   ) no_update=1 ;;
+      -L | --no-login    ) no_login=1 ;;
+
+      ####################################
+      ### END: PROCESS COMMAND OPTIONS ###
+      ####################################
+
+      # Don't modify these.
+      -|''|[^-]*) set -- "$@" "$opt" ;;                                            # positional parameter, rotate to the end
+      --*=*)      set -- "${opt%%=*}" "${opt#*=}" "$@" ;;                          # convert '--name=arg' to '--name' 'arg'
+      -[^-]?*)    set -- $(echo "${opt#-}" | sed 's/\(.\)/ -\1/g') "$@" ;;         # convert '-abc' to '-a' '-b' '-c'
+      --)         while [ "$1" != "$EOL" ] ; do set -- "$@" "$1" ; shift ; done ;; # process remaining arguments as positional
+      -*)         usage_error "Unknown option: '$opt'" ;;                          # catch misspelled options
+      *)          usage_error "This should never happen ($opt)" ;;                 # sanity test for previous patterns
+    esac
+  done
+  shift
+fi
+
+# Helper functions to decide whether a step can be executed.
+# @todo Is /dev/null cross-platform compatible?
+has_upstream       () { git rev-parse "${branch}@{upstream}" 1>/dev/null 2>&1 ; }
+can_change_branch  () { [ -n "$branch" ]                                      ; }
+can_update_git     () { [ $no_git_pull   -eq 0 ] && has_upstream              ; }
+can_skip_prompts   () { [ $skip_prompts  -eq 1 ]                              ; }
+can_restart_ddev   () { [ $no_restart    -eq 0 ]                              ; }
+can_build_composer () { [ $no_composer   -eq 0 ]                              ; }
+can_build_assets   () { [ $no_assets     -eq 0 ]                              ; }
+can_import_db      () { [ $can_import_db -eq 1 ]                              ; }
+can_download_db    () { [ $existing_sql  -eq 0 ]                              ; }
+can_skip_download  () { [ $existing_sql  -eq 1 ]                              ; }
+can_update_drupal  () { [ $no_update     -eq 0 ]                              ; }
+can_log_in         () { [ $no_login      -eq 0 ]                              ; }
+
+# Helper function to prompt user for confirmation before proceeding.
+confirm () {
+  question="$1"
+  help_text="$2"
+  printf "\n$question (yes/no) [yes]: \n"
+  if can_skip_prompts ; then
+    echo "> yes"
+  else
+    read -p "> " -r
+    printf '\n'
+    case $(echo "$REPLY" | tr '[A-Z]' '[a-z]') in
+      # On "y", "yes", or no input (default action), okay to proceed (no exit).
+      yes | y | "" ) ;;
+      # Any other response...
+      * )
+        if [ -n "$help_text" ] ; then
+          echo "$help_text"
+        fi
+        exit 0
+        ;;
+    esac
+  fi
+}
+
+# Use the first "positional parameter" as git branch. Note: All the options
+# have been popped from the args list, so only positional parameters are left.
+branch="$1"
+
+# Ensure no other positional parameters were passed.
+if [ "$#" -gt 1 ] ; then
+  usage_error "This command only takes one argument (git branch name), got \"$*\""
+fi
+
+# Check for invalid options combinations.
+if can_skip_download && (! can_import_db) ; then
+  usage_error 'The "--existing-sql" option requires "--import-db".'
+fi
+
+# Make sure an existing database file is present, if requested.
+db_dump_exists () { [ -f "${DDEV_APPROOT}/files/private/db.sql" ] ; }
+if can_import_db && can_skip_download && (! db_dump_exists) ; then
+  usage_error \
+    'There is no previously-downloaded database dump. Rerun this command without "--existing-sql" to download a new file.'
+fi
+
+# Confirm reverting Drupal configuration changes.
+has_config_changes () { ! ddev task drupal:config:check >/dev/null 2>&1 ; }
+if can_update_drupal && (! can_import_db) && has_config_changes ; then
+  printf '\nYour local environment has some Drupal configuration overrides:\n\n'
+  if ! ddev drush config:status ; then
+    usage_error 'Mismatch between code and database. Add the "--import-db" option to reinitialize the database.'
+  fi
+  confirm \
+    'Discard these configuration overrides and proceed?' \
+    'To preserve configuration changes, export them to code with "drush config:export", and either commit them to a different/temporary branch, or stash the changes with "git stash".'
+fi
+
+# Confirm importing the database.
+if can_import_db ; then
+  confirm \
+    'Importing the database replaces all content in your Drupal DB. Okay to discard local content changes?' \
+    'To skip the database import step, rerun this command without the "--import-db" option.'
+fi
+
+# Helper function to print command before executing it.
+announce () {
+  step_is_allowed="$1"
+  step="${@:2}"
+  if $step_is_allowed ; then
+    # Print the command first.
+    printf "\n\$ $step\n"
+    # Perform the step (execute the command).
+    $step
+    printf '\n'
+  elif [ $verbose ] ; then
+    echo "[info] Skipping \"$step\""
+  fi
+}
+
+# Abort the rest of the script if any command fails from here onward.
+set -e
+
+# Steps to refresh.
+announce can_change_branch   git fetch $verbose
+announce can_change_branch   git checkout "$branch" $verbose
+announce can_update_git      git pull $verbose
+announce can_restart_ddev    ddev restart
+announce can_build_composer  ddev task drupal:composer:development $verbose
+announce can_build_assets    ddev task assets $verbose
+announce can_download_db     ddev task acquia:fetch-db $verbose
+announce can_import_db       ddev task drupal:import-db
+announce can_update_drupal   ddev task drupal:update $verbose
+announce can_log_in          ddev login $verbose
+
+printf "\nDone refreshing. Success!\n"

--- a/custom-commands/drupal-refresh/host/refresh
+++ b/custom-commands/drupal-refresh/host/refresh
@@ -188,7 +188,7 @@ announce can_build_composer ddev composer install --optimize-autoloader $verbose
 announce can_build_assets   ddev gulp $verbose # Requires the gulp command from ddev-contrib
 announce can_download_db    echo 'download db here' # https://ddev.readthedocs.io/en/stable/users/providers/provider-introduction
 announce can_import_db      ddev import-db
-announce can_update_drupal  ddev update_drupal
+announce can_update_drupal  update_drupal
 announce can_log_in         ddev login $verbose # Requires the drupal-login command from ddev-contrib
 
 printf "\nDone refreshing. Success!\n"

--- a/custom-commands/drupal-refresh/host/refresh
+++ b/custom-commands/drupal-refresh/host/refresh
@@ -125,7 +125,7 @@ if can_import_db && can_skip_download && (! db_dump_exists) ; then
 fi
 
 # Confirm reverting Drupal configuration changes.
-has_config_changes () { ! ddev task drupal:config:check >/dev/null 2>&1 ; }
+has_config_changes () { [ $(./vendor/bin/drush config:status --format=string | wc -w) -ne 0 ] >/dev/null 2>&1 ; }
 if can_update_drupal && (! can_import_db) && has_config_changes ; then
   printf '\nYour local environment has some Drupal configuration overrides:\n\n'
   if ! ddev drush config:status ; then
@@ -142,6 +142,24 @@ if can_import_db ; then
     'Importing the database replaces all content in your Drupal DB. Okay to discard local content changes?' \
     'To skip the database import step, rerun this command without the "--import-db" option.'
 fi
+
+# Adapted from https://architecture.lullabot.com/adr/20210924-drupal-build-steps
+update_drupal () {
+  announce true ddev drush cache:clear plugin -y
+  # Run numbered module updates (hook_update_N) only.
+  announce true ddev drush updatedb --no-post-updates -y
+  # Run config:import twice to make sure we catch any config that didn't declare
+  # a dependency correctly. This is also useful when importing large config sets
+  # as it can sometimes hit an out of memory error.
+  # @todo The `|| true` doesn't work with the announce script. set -e will
+  # still cause the script to fail.
+  announce true ddev drush config:import -y || true
+  announce true ddev drush config:import -y
+  # Run updatedb again for updates dependent on config changes
+  # This second run should fire all hook_post_update_NAME() hooks.
+  announce true ddev drush updatedb --no-cache-clear -y
+  announce true ddev drush cache:rebuild -y
+}
 
 # Helper function to print command before executing it.
 announce () {
@@ -162,15 +180,15 @@ announce () {
 set -e
 
 # Steps to refresh.
-announce can_change_branch   git fetch $verbose
-announce can_change_branch   git checkout "$branch" $verbose
-announce can_update_git      git pull $verbose
-announce can_restart_ddev    ddev restart
-announce can_build_composer  ddev task drupal:composer:development $verbose
-announce can_build_assets    ddev task assets $verbose
-announce can_download_db     ddev task acquia:fetch-db $verbose
-announce can_import_db       ddev task drupal:import-db
-announce can_update_drupal   ddev task drupal:update $verbose
-announce can_log_in          ddev login $verbose
+announce can_change_branch  git fetch $verbose
+announce can_change_branch  git checkout "$branch" $verbose
+announce can_update_git     git pull $verbose
+announce can_restart_ddev   ddev restart
+announce can_build_composer ddev composer install --optimize-autoloader $verbose
+announce can_build_assets   ddev gulp $verbose # Requires the gulp command from ddev-contrib
+announce can_download_db    echo 'download db here' # https://ddev.readthedocs.io/en/stable/users/providers/provider-introduction
+announce can_import_db      ddev import-db
+announce can_update_drupal  ddev update_drupal
+announce can_log_in         ddev login $verbose # Requires the drupal-login command from ddev-contrib
 
 printf "\nDone refreshing. Success!\n"


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The Problem:

Cleaning up/initializing your Drupal environment to begin new work, or switching branches to test someone else's work, requires several steps. It's easy to forget some of them, and it takes cognitive load to remember. Lots of folks write a little custom bash alias/script to handle it for them on a given project. This is just a very complete version of that, and can be used on most Drupal projects.

The steps required to refresh a Drupal environment include:
- fetch the latest code
- download and import a database
- compile front-end assets
- composer install
- execute Drupal database updates
- rebuild caches
- and other stuff

## How this PR Solves The Problem:

Provides a single command to completely (re)initialize/refresh your ddev Drupal environment. Supports various flags to turn steps on and off. See [README.md](https://github.com/drud/ddev-contrib/pull/203/files#diff-bf0abf979451af33056d114653041dd2c241b75c37522016112a8fcc7a0c3653) for the full list of options. This command is especially useful when collaborating with other developers or otherwise switching between branches for testing.

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

1. Create a ddev Drupal environment. You can follow the [Drupal.org documentation](https://www.drupal.org/docs/official_docs/en/_local_development_guide.html), or use an existing site you have.

1. Copy the `refresh` script into place: `.ddev/commands/host/refresh`

1. Also install the [`drupal-login`](https://github.com/drud/ddev-contrib/tree/master/custom-commands/drupal-login) and [`gulp`](https://github.com/drud/ddev-contrib/tree/master/custom-commands/gulp) custom commands from ddev-contrib.

1. Run `ddev refresh`, and see that all the default steps run.

1. Run `ddev refresh some-existing-branch` and see that an existing branch is checked out + pulled before refreshing.

1. Run `ddev refresh -h` and see all the options available. Try out some them. E.g., `--no-restart` to skip restarting ddev, and `--no-login` to skip the login step at the end.

1. The only two steps you can't (easily) test are `--import-db` and `--existing-sql` to download and import a database dump from some upstream environment, as those are usually project specific and require some extra setup to use. Since they don't run by default, I chose to leave them in place for users to leverage if they wish.

## Manual Testing Environments:

- [ ] Windows
- [ ] MacOS
- [ ] Linux