### PR TITLE
WIP: Add adminer

### DIFF
--- a/docker-compose-services/adminer/docker-compose.adminer.yaml
+++ b/docker-compose-services/adminer/docker-compose.adminer.yaml
@@ -1,0 +1,20 @@
+version: '3.6'
+services:
+  adminer:
+    container_name: ddev-${DDEV_SITENAME}-adminer
+    image: adminer:standalone
+    environment:
+      # - ADMINER_DESIGN=nette
+      - ADMINER_DEFAULT_SERVER=ddev-${DDEV_SITENAME}-db
+      - ADMINER_PLUGINS=tables-filter
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.site.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # HTTP_EXPOSE allows for ports accepting HTTP traffic to be accessible from <site>.ddev.site:<port>
+      - HTTP_EXPOSE=8080:8080
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+  web:
+    links:
+      - adminer:adminer


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
Add adminer service, see https://github.com/drud/ddev/issues/3534

## How this PR Solves The Problem:
Adds adminer as a service to ddev, allowing to manage databases with it.

## Manual Testing Instructions:
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->
- Adminer listens to sitename.ddev.site:8080
- Username, password and dbname need to be filled by hand (`db` everywhere in ddev with mysql)

## Remaining Tasks
- [x] Add readme
- [ ] Get feedback

## Nice to have
- [ ] Allow passwordless login
- [ ] Add theme switcher plugin (need to figure out how)