### PR TITLE
Rid extra characters from docker-compose.chrome

### DIFF
--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -1,4 +1,3 @@
----
 version: '3.6'
 services:
     chrome:


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

Rid extra characters from docker-compose.chrome.yaml

## How this PR Solves The Problem:

Running docker composer without issue

## Manual Testing Instructions:

## Related Issue Link(s):

