### PR TITLE
Rid extra characters from docker-compose.chrome

### DIFF
--- a/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
+++ b/docker-compose-services/drupalci-chromedriver/docker-compose.chromedriver.yaml
@@ -1,4 +1,3 @@
----
 # Docker-ChromeDriver configuration for DDEV-Local.
 # There is one item that must be configured in this file in order for it to
 # work, please see below.

--- a/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
+++ b/docker-compose-services/headless-chrome/docker-compose.chrome.yaml
@@ -1,4 +1,3 @@
----
 version: '3.6'
 services:
     chrome:


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:
Rid extra characters from docker-compose.chrome

## How this PR Solves The Problem:
Running docker composer without issue

## Manual Testing Instructions:

## Related Issue Link(s):

