### PR TITLE
Add env_file support on env snippet.

### DIFF
--- a/docker-compose-snippets/environment-variable/docker-compose.env.yaml
+++ b/docker-compose-snippets/environment-variable/docker-compose.env.yaml
@@ -2,5 +2,11 @@ version: '3.6'
 
 services:
   web:
+
+    # Provide environment variables directly.
     environment:
       - TYPO3_CONTEXT=Development
+
+    # Alternatively point to an env file you'll need to create in the project root.
+    env_file:
+      - ../.env


### PR DESCRIPTION
<!-- 
Remember:
* If you're adding something new, please add a fully descriptive README.md, and remember that not everybody will know what you're talking about, so include links to the technology you're using and step-by-step installation instructions.
* If you're adding something new, please add a link to it in the top-level README.md
* Please add a footer to your README.md like `**Contributed by [@<you>](https://github.com/<you>)**` If there are many contributors, you may want to add them all. This helps future users figure out who the subject matter experts are. 
-->

## The New Solution/Problem/Issue/Bug:
No env file support provided on the env snippet.

## How this PR Solves The Problem:
Provides example snippet with comment. Allows docker-compose to load env files. This is a widely known issue with ddev, i.e. the lack of env file support.

Taken from the offical docs:
https://docs.docker.com/compose/environment-variables/#the-env_file-configuration-option

## Manual Testing Instructions:
- Add snippet to .ddev folder
- Add .env file to project root, declaring at least one environment variable.
- Boot the ddev project. In the project code do `print_r($_ENV);`
- Refresh front-end - given environment variable(s) in the env file should be present in the array.
<!-- 
Remember that the reviewer may not have any familiarity 
with what you're adding here, so give links to any 
technologies you're using and give step-by-step instructions 
-->

## Related Issue Link(s):
 
