### PR TITLE
Bump meilisearch to 0.27.2, adds arm64 support

### DIFF
--- a/docker-compose-services/meilisearch/README.md
+++ b/docker-compose-services/meilisearch/README.md
@@ -1,9 +1,8 @@
 # Meilisearch
 
-[Meilisearch](https://www.meilisearch.com/) is an open source search-engine and can be used in ddev to handle searchindexes for the Drupal search_api.
-Using official meilisearch v0.20.0 container [meilisearch](https://hub.docker.com/r/getmeili/meilisearch).
+[Meilisearch](https://www.meilisearch.com/) is an open source search-engine. It can be used in ddev to handle search indexes for the Drupal search_api, or as a backend for Laravel Scout.
 
-**Warning for Mac M1/arm64 users**: Because the old meilisearch v0.20.0 image does not provide arm64 images, this can't be used on mac M1 or other arm64 systems.
+Using official meilisearch v0.27.2 container [meilisearch](https://hub.docker.com/r/getmeili/meilisearch).
 
 ## Installation
 
@@ -17,11 +16,12 @@ From within the container, the meilisearch container is reached at hostname: `dd
 
 You can access the Meilisearch server directly from the host for debugging purposes by visiting `http://<projectname>.ddev.site:7700`.
 
-You can use `ddev logs -s meilisearch` to investigate what the meilissearch daemon has been up to.
+You can use `ddev logs -s meilisearch` to investigate what the meilisearch daemon has been up to.
 
 ## Additional Resources
 
 - [Drupal search_api_meilisearch module](https://www.drupal.org/project/search_api_meilisearch)
-- [Meiliseearch docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html)
+- [Meilisearch docs](https://docs.meilisearch.com/learn/getting_started/quick_start.html)
+- [Laravel Scout](https://laravel.com/docs/9.x/scout)
 
 **Contributed by [@thilohille](https://github.com/thilohille)**

--- a/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
+++ b/docker-compose-services/meilisearch/docker-compose.meilisearch.yaml
@@ -2,7 +2,7 @@ version: '3.6'
 services:
   meilisearch:
     container_name: ddev-${DDEV_SITENAME}-meilisearch
-    image: getmeili/meilisearch:v0.20.0
+    image: getmeili/meilisearch:v0.27.2
     hostname: ${DDEV_SITENAME}-meilisearch
     expose:
       - "7700"


### PR DESCRIPTION
## The New Solution/Problem/Issue/Bug:

The previous meilisearch image did not support arm64/Apple Silicon

## How this PR Solves The Problem:

The image is upgraded to version 0.27.2 (there's arm64 support since version 0.25). The documentation is updated accordingly.

## Manual Testing Instructions:

Use the provided `docker-compose.meilisearch.yaml` file. After starting, the service should be available at: `http://ddev-<projectname>-meilisearch:7700`

## Related Issue Link(s):

#186 
