### PR TITLE
Update “DDEV” usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# ddev-contrib: Contrib for DDEV-Local
+# ddev-contrib: Contrib for DDEV
 
-Contrib space for DDEV-Local services, tools, snippets, approaches.
+Contrib space for DDEV services, tools, snippets, and approaches.
 
 ## config.yaml hook examples
 
-* [Import a sql dump if database is empty](hook-examples/import-db-if-empty/)
+* [Import a SQL dump if database is empty](hook-examples/import-db-if-empty/)
 
 ## docker-compose.*.yaml snippets to solve simple problems
 
@@ -12,16 +12,16 @@ Don't forget the [Official documentation](https://ddev.readthedocs.io/en/stable/
 
 * [Mounting a directory into web container](docker-compose-snippets/mounting-directory/)
 * [Setting an environment variable](docker-compose-snippets/environment-variable/docker-compose.env.yaml)
-* [Communication between two ddev projects](docker-compose-snippets/project-communication/)
+* [Communication between two DDEV projects](docker-compose-snippets/project-communication/)
 * [Set default language (or other settings) in phpmyadmin](docker-compose-snippets/phpmyadmin-user-settings/)
 
 ## Custom command examples
 
-Ddev's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/custom-commands/) are a great way to add team-level or project-level commands. They're simple scripts that can be run in any of the containers or on the host. Note that several examples are already shipped with ddev, you'll find them in .ddev/commands/*/*.example, and then can be enabled by symlinking or copying.)
+DDEV's [custom commands](https://ddev.readthedocs.io/en/latest/users/extend/custom-commands/) are a great way to add team-level or project-level commands. They're simple scripts that can be run in any of the containers or on the host. Note that several examples are already shipped with DDEV, you'll find them in .ddev/commands/*/*.example, and then can be enabled by symlinking or copying.)
 
 * [Dump and deploy SQL from/to remote servers](custom-commands/dump-and-deploy-db/)
 * [Fetch Production DB from remote server](custom-commands/fetchproductiondb/)
-* [Exclude ddev directory from git: git-exclude](custom-commands/git-exclude)
+* [Exclude DDEV directory from git: git-exclude](custom-commands/git-exclude)
 * [Enable and view MySQL/MariaDB GENERAL_LOG](custom-commands/general-log/)
 * [inotify-proxy to enable file watchers on NFS shares](custom-commands/inotify-proxy)
 * [Executing Symfony console and phpunit commands without ssh](custom-commands/symfony/)
@@ -66,7 +66,7 @@ General information on how to do additional services and some additional example
 
 ## Full recipes
 
-* [Using ddev with a corporate (or other) web proxy (obsolete - use `ddev get drud/ddev-proxy-support`)](recipes/proxy)
+* [Using DDEV with a corporate (or other) web proxy (obsolete - use `ddev get drud/ddev-proxy-support`)](recipes/proxy)
 * [enable TYPO3 cronjob on start or on demand (typo3 scheduler:run)](recipes/cronjob/)
 * [Setting up Drupal 8 multisite, including Drush support](recipes/drupal8-multisite/)
 * [Bludit CMS](recipes/bludit-cms)


### PR DESCRIPTION
Quick readme edit that consistently uses “DDEV” for product name. Also capitalizes “SQL” because I couldn’t help it.