### PR TITLE
Update docker-compose.solr.yaml

### DIFF
--- a/docker-compose-services/solr-7/docker-compose.solr.yaml
+++ b/docker-compose-services/solr-7/docker-compose.solr.yaml
@@ -21,8 +21,6 @@
 #   accessed at the URL: http://solr:8983/solr/dev (inside web container)
 #   or at http://myproject.ddev.site:8983/solr/dev (on the host)
 
-version: '3.6'
-
 services:
   solr:
     # Name of container using standard ddev convention
@@ -34,7 +32,7 @@ services:
     image: solr:7
     restart: "no"
     # Solr is served from this port inside the container.
-    ports:
+    expose:
       - 8983
     # These labels ensure this service is discoverable by ddev.
     labels:
@@ -72,6 +70,8 @@ services:
 
     external_links:
       - "ddev-router:${DDEV_SITENAME}.${DDEV_TLD}"
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail -s localhost:8983/solr/"]
 
   # This links the Solr service to the web service defined in the main
   # docker-compose.yml, allowing applications running inside the web container to
@@ -84,3 +84,4 @@ volumes:
   # The persistent volume should have the same name as the service so it can be deleted
   # when the project is deleted.
   solr:
+    name: "ddev-${DDEV_SITENAME}_solr"


### PR DESCRIPTION
Adding changes to supress warnings.

## The New Solution/Problem/Issue/Bug:
When using acquia_search setting things up locally takes a bit of work. I have been using this contrib project with the following tweaks.

## How this PR Solves The Problem:
This stops warings about version being out of date and allows ddev to connect to the solr container from within Drupal.

## Caveat:
Now that Acquia have updated their Solr servers this workaround may no longer be needed and so the caveat in the README.md file at: https://github.com/ddev/ddev-drupal-solr may need to be updated to say that the project can now be used with acquia_search